### PR TITLE
Fix #510 reimpl. validação de datas em Fil.Partid.

### DIFF
--- a/sapl/base/templatetags/menus.py
+++ b/sapl/base/templatetags/menus.py
@@ -41,7 +41,7 @@ def subnav(context, path=None):
         if path:
             yaml_path = path
         elif 'subnav_template_name' in context:
-            yaml_path  = context['subnav_template_name']
+            yaml_path = context['subnav_template_name']
         else:
             yaml_path = '%s/%s' % (app_template, 'subnav.yaml')
 


### PR DESCRIPTION
reimplementa validar_datas em inserção/edição de filiações partidárias
devido a existência de lacunas e erros de inserção de novas filiações
com datas e intervalos válidos.