### PR TITLE
Inclusão/exclusão da presença dos parlamentares na Sessão Plenária e Ordem do Dia

### DIFF
--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -30,7 +30,7 @@ from sapl.materia.models import (Autoria, DocumentoAcessorio,
 from sapl.materia.views import MateriaLegislativaPesquisaView
 from sapl.norma.models import NormaJuridica
 from sapl.parlamentares.models import (Filiacao, Legislatura, Parlamentar,
-                                       SessaoLegislativa)
+                                       SessaoLegislativa, Mandato)
 from sapl.sessao.apps import AppConfig
 from sapl.sessao.forms import ExpedienteMateriaForm, OrdemDiaForm
 
@@ -561,7 +561,12 @@ class PresencaMixin:
         )
         presentes = [p.parlamentar for p in presencas]
 
-        for parlamentar in Parlamentar.objects.filter(ativo=True):
+        mandato = Mandato.objects.filter(
+            legislatura_id=self.object.legislatura_id)
+
+        mandato_parlamentar = [p.parlamentar for p in mandato]
+
+        for parlamentar in mandato_parlamentar:
             if parlamentar in presentes:
                 yield (parlamentar, True)
             else:
@@ -575,7 +580,12 @@ class PresencaMixin:
         )
         presentes = [p.parlamentar for p in presencas]
 
-        for parlamentar in Parlamentar.objects.filter(ativo=True):
+        mandato = Mandato.objects.filter(
+            legislatura_id=self.object.legislatura_id)
+
+        mandato_parlamentar = [p.parlamentar for p in mandato]
+
+        for parlamentar in mandato_parlamentar:
             if parlamentar in presentes:
                 yield (parlamentar, True)
             else:
@@ -605,13 +615,13 @@ class PresencaView(FormMixin, PresencaMixin, DetailView):
                 sessao_plenaria_id=self.object.id)
 
             # Id dos parlamentares presentes
-            marcados = request.POST.getlist('presenca')
+            marcados = request.POST.getlist('presenca_ativos') + request.POST.getlist('presenca_inativos')
 
             # Deletar os que foram desmarcadors
             deletar = set(set(presentes_banco) - set(marcados))
             for d in deletar:
                 SessaoPlenariaPresenca.objects.filter(
-                    parlamentar_id=d.parlamentar_id).delete()
+                    parlamentar_id=d.parlamentar_id, sessao_plenaria_id=self.object.id).delete()
 
             for p in marcados:
                 sessao = SessaoPlenariaPresenca()
@@ -713,13 +723,13 @@ class PresencaOrdemDiaView(FormMixin, PresencaMixin, DetailView):
                 sessao_plenaria_id=pk)
 
             # Id dos parlamentares presentes
-            marcados = request.POST.getlist('presenca')
+            marcados = request.POST.getlist('presenca_ativos') + request.POST.getlist('presenca_inativos')
 
             # Deletar os que foram desmarcadors
             deletar = set(set(presentes_banco) - set(marcados))
             for d in deletar:
                 PresencaOrdemDia.objects.filter(
-                    parlamentar_id=d.parlamentar_id).delete()
+                    parlamentar_id=d.parlamentar_id, sessao_plenaria_id=self.object.id).delete()
 
             for p in marcados:
                 ordem = PresencaOrdemDia()

--- a/sapl/templates/sessao/presenca.html
+++ b/sapl/templates/sessao/presenca.html
@@ -17,17 +17,37 @@
 				</label>
 			</div>
 		</div>
-		<br />
-		<div class="controls">
-			{% for parlamentar, check in view.get_presencas %}
-		    <div class="checkbox">
-					<label for="id_presenca_{{forloop.counter}}">
-						<input type="checkbox" id="id_presenca_{{forloop.counter}}" name="presenca" value="{{ parlamentar.id }}" {% if check %} checked {% endif %}/>
-						{{ parlamentar.nome_parlamentar }} / {{ parlamentar.filiacao_atual }}
-					</label>
-		    </div>
-			{% endfor %}
-		</div>
+
+                <br />
+                <div class="controls"> 
+                        <div class="checkbox"> 
+                                <label for="id_ativos">
+                                        <input type="checkbox" name="ativos" id="id_ativos" onchange="escondeInativos()" checked /> Exibir somente parlamentares ativos
+                                </label>
+                        </div>
+                </div>
+
+              <br />
+
+      <div class="controls">
+        {% for parlamentar, check in view.get_presencas %}
+          {% if parlamentar.ativo %}
+          <div class="checkbox">
+            <label for="id_presenca_{{forloop.counter}}">
+              <input type="checkbox" id="id_presenca_{{forloop.counter}}" name="presenca_ativos" value="{{ parlamentar.id }}" {% if check %} checked {% endif %}/>
+              {{ parlamentar.nome_parlamentar }} / {{ parlamentar.filiacao_atual }}                        
+            </label>
+          </div>
+          {% else %}
+          <div class="checkbox inativos" style="display:none;">
+            <label for="id_presenca_{{forloop.counter}}">
+              <input type="checkbox" id="id_presenca_{{forloop.counter}}" name="presenca_inativos" value="{{ parlamentar.id }}" {% if check %} checked {% endif %}/>
+              {{ parlamentar.nome_parlamentar }} / {{ parlamentar.filiacao_atual }}      
+            </label>
+          </div>
+          {% endif %}
+        {% endfor %}
+      </div>
 
 		<br />
 		<input type="submit" value="Salvar" class="btn btn-primary" />
@@ -55,10 +75,21 @@
 {% block extra_js %}
 	<script language="JavaScript">
 		function checkAll(event) {
-			$('[name=presenca]').each(function() {
+			$('[name=presenca_ativos]').each(function() {
 				$(this).prop('checked', event.target.checked ? 'checked': null);
 				$(this).trigger('click');
 			});
+			if (($('[name=ativos]').is(':checked')) == false) {
+                        	$('[name=presenca_inativos]').each(function() {
+                	                $(this).prop('checked', event.target.checked ? 'checked': null);
+        	                        $(this).trigger('click');
+ 	                       });
+ 			}
+
 		}
+
+                function escondeInativos() {
+                        $(".inativos").toggle();
+                }
 	</script>
 {% endblock %}

--- a/sapl/templates/sessao/presenca_ordemdia.html
+++ b/sapl/templates/sessao/presenca_ordemdia.html
@@ -17,18 +17,38 @@
         </label>
       </div>
     </div>
-    <br>
+
+    <br />
 
     <div class="controls">
-		{% for parlamentar, check in view.get_presencas_ordem %}
       <div class="checkbox">
-      <label for="id_presenca_{{forloop.counter}}">
-        <input type="checkbox" id="id_presenca_{{forloop.counter}}" name="presenca" value="{{ parlamentar.id }}" {% if check %} checked {% endif %}/>
-        {{ parlamentar.nome_parlamentar }} / {{ parlamentar.filiacao_atual }}
-      </label>
+        <label for="id_ativos">
+          <input type="checkbox" name="ativos" id="id_ativos" onchange="escondeInativos()" checked /> Exibir somente parlamentares ativos
+        </label>
       </div>
-		{% endfor %}
     </div>
+
+    <br />
+
+      <div class="controls">
+        {% for parlamentar, check in view.get_presencas_ordem %}
+          {% if parlamentar.ativo %}
+          <div class="checkbox">
+            <label for="id_presenca_{{forloop.counter}}">
+              <input type="checkbox" id="id_presenca_{{forloop.counter}}" name="presenca_ativos" value="{{ parlamentar.id }}" {% if check %} checked {% endif %}/>
+              {{ parlamentar.nome_parlamentar }} / {{ parlamentar.filiacao_atual }}
+            </label>
+          </div>
+          {% else %}
+          <div class="checkbox inativos" style="display:none;">
+            <label for="id_presenca_{{forloop.counter}}">
+              <input type="checkbox" id="id_presenca_{{forloop.counter}}" name="presenca_inativos" value="{{ parlamentar.id }}" {% if check %} checked {% endif %}/>
+              {{ parlamentar.nome_parlamentar }} / {{ parlamentar.filiacao_atual }}
+            </label>
+          </div>
+          {% endif %}
+        {% endfor %}
+      </div>
 
 		<br />
 		<input type="submit" value="Salvar" class="btn btn-primary" />
@@ -56,10 +76,21 @@
 {% block extra_js %}
 	<script language="JavaScript">
 		function checkAll(event) {
-      $('[name=presenca]').each(function() {
-        $(this).prop('checked', event.target.checked ? 'checked': null);
-        $(this).trigger('click');
-      });
-		}
+                        $('[name=presenca_ativos]').each(function() {
+                                $(this).prop('checked', event.target.checked ? 'checked': null);
+                                $(this).trigger('click');
+                        });
+                        if (($('[name=ativos]').is(':checked')) == false) {
+                                $('[name=presenca_inativos]').each(function() {
+                                        $(this).prop('checked', event.target.checked ? 'checked': null);
+                                        $(this).trigger('click');
+                               });
+                        }
+
+                }
+
+                function escondeInativos() {
+                        $(".inativos").toggle();
+                }
 	</script>
 {% endblock %}


### PR DESCRIPTION
Exibição dos parlamentares para definir presença/ausência, tanto na Sessão Plenária quanto na Ordem do Dia. Tela de alteração para operador logado.
Trata a issue #1054 Parlamentares presentes na sessão e ordem do dia.