### PR TITLE
Ajuste na presença de parlamentares na sessão e ordem do dia

### DIFF
--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -611,7 +611,6 @@ class PresencaView(FormMixin, PresencaMixin, DetailView):
             # Id dos parlamentares presentes
             marcados = request.POST.getlist('presenca_ativos') \
                      + request.POST.getlist('presenca_inativos')
-            marcados = list(map(lambda x: int(x), marcados))
 
             # Deletar os que foram desmarcados
             deletar = set(presentes_banco) - set(marcados)
@@ -722,7 +721,6 @@ class PresencaOrdemDiaView(FormMixin, PresencaMixin, DetailView):
             # Id dos parlamentares presentes
             marcados = request.POST.getlist('presenca_ativos') \
                      + request.POST.getlist('presenca_inativos')
-            marcados = list(map(lambda x: int(x), marcados))
 
             # Deletar os que foram desmarcados
             deletar = set(presentes_banco) - set(marcados)


### PR DESCRIPTION
No caso de alteração na presença de parlamentares na Sessão Plenária e na Ordem do Dia, o sistema não está apagando os registros antigos antes de gravar os novos. Tal inconsistência é percebida no resumo da sessão e, no caso da Ordem do Dia, também no painel de votação.