### PR TITLE
Fix #1550

### DIFF
--- a/sapl/base/forms.py
+++ b/sapl/base/forms.py
@@ -409,7 +409,7 @@ class RelatorioAtasFilterSet(django_filters.FilterSet):
         self.form.helper.form_method = 'GET'
         self.form.helper.layout = Layout(
             Fieldset(_('Atas das Sessões Plenárias'),
-                     row1, form_actions(save_label='Pesquisar'))
+                     row1, form_actions(label='Pesquisar'))
         )
 
 
@@ -439,7 +439,7 @@ class RelatorioPresencaSessaoFilterSet(django_filters.FilterSet):
         self.form.helper.form_method = 'GET'
         self.form.helper.layout = Layout(
             Fieldset(_('Presença dos parlamentares nas sessões plenárias'),
-                     row1, form_actions(save_label='Pesquisar'))
+                     row1, form_actions(label='Pesquisar'))
         )
 
     @property
@@ -483,7 +483,7 @@ class RelatorioHistoricoTramitacaoFilterSet(django_filters.FilterSet):
         self.form.helper.layout = Layout(
             Fieldset(_('Histórico de Tramita'),
                      row1, row2,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -514,7 +514,7 @@ class RelatorioMateriasTramitacaoilterSet(django_filters.FilterSet):
         self.form.helper.layout = Layout(
             Fieldset(_('Pesquisa de Matéria em Tramitação'),
                      row1, row2, row3, row4,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -540,7 +540,7 @@ class RelatorioMateriasPorAnoAutorTipoFilterSet(django_filters.FilterSet):
         self.form.helper.layout = Layout(
             Fieldset(_('Pesquisar'),
                      row1,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -586,7 +586,7 @@ class RelatorioMateriasPorAutorFilterSet(django_filters.FilterSet):
                      HTML(autor_label),
                      HTML(autor_modal),
                      row3,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -692,7 +692,7 @@ class RecuperarSenhaForm(PasswordResetForm):
         self.helper.layout = Layout(
             Fieldset(_('Insira o e-mail cadastrado com a sua conta'),
                      row1,
-                     form_actions(save_label='Enviar'))
+                     form_actions(label='Enviar'))
         )
 
         super(RecuperarSenhaForm, self).__init__(*args, **kwargs)
@@ -723,4 +723,4 @@ class NovaSenhaForm(SetPasswordForm):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             row1,
-            form_actions(save_label='Enviar'))
+            form_actions(label='Enviar'))

--- a/sapl/crispy_layout_mixin.py
+++ b/sapl/crispy_layout_mixin.py
@@ -1,6 +1,5 @@
 from math import ceil
 
-import rtyaml
 from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Div, Fieldset, Layout, Submit
@@ -8,6 +7,7 @@ from django import template
 from django.core.urlresolvers import reverse
 from django.utils import formats
 from django.utils.translation import ugettext as _
+import rtyaml
 
 
 def heads_and_tails(list_of_lists):
@@ -34,9 +34,10 @@ def to_fieldsets(fields):
             yield field
 
 
-def form_actions(more=[], save_label=_('Salvar')):
+def form_actions(more=[],
+                 label=_('Salvar'), name='salvar', css_class='pull-right'):
     return FormActions(
-        Submit('salvar', save_label, css_class='pull-right',
+        Submit(name, label, css_class=css_class,
                # para impedir resubmissão do form
                onclick='this.form.submit();this.disabled=true;'),
         *more)
@@ -49,7 +50,7 @@ class SaplFormLayout(Layout):
 
         buttons = actions
         if not buttons:
-            buttons = form_actions(save_label=save_label, more=[
+            buttons = form_actions(label=save_label, more=[
                 HTML('<a href="{{ view.cancel_url }}"'
                      ' class="btn btn-inverse">%s</a>' % cancel_label)
                 if cancel_label else None])

--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -1,7 +1,6 @@
 
 import os
 
-import django_filters
 from crispy_forms.bootstrap import Alert, FormActions, InlineRadios
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import (HTML, Button, Column, Div, Field, Fieldset,
@@ -22,8 +21,8 @@ from django.utils.encoding import force_text
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
+import django_filters
 
-import sapl
 from sapl.base.models import Autor, TipoAutor
 from sapl.comissoes.models import Comissao
 from sapl.compilacao.models import (STATUS_TA_IMMUTABLE_PUBLIC,
@@ -42,6 +41,7 @@ from sapl.utils import (RANGE_ANOS, YES_NO_CHOICES,
                         MateriaPesquisaOrderingFilter, RangeWidgetOverride,
                         autor_label, autor_modal, models_with_gr_for_model,
                         qs_override_django_filter)
+import sapl
 
 from .models import (AcompanhamentoMateria, Anexada, Autoria, DespachoInicial,
                      DocumentoAcessorio, Numeracao, Proposicao, Relatoria,
@@ -73,7 +73,7 @@ class AdicionarVariasAutoriasFilterSet(django_filters.FilterSet):
         self.form.helper.form_method = 'GET'
         self.form.helper.layout = Layout(
             Fieldset(_('Filtrar Autores'),
-                     row1, form_actions(save_label='Filtrar'))
+                     row1, form_actions(label='Filtrar'))
         )
 
 
@@ -86,7 +86,7 @@ class ReceberProposicaoForm(Form):
         self.helper.layout = Layout(
             Fieldset(
                 _('Incorporar Proposição'), row1,
-                form_actions(save_label='Buscar Proposição')
+                form_actions(label='Buscar Proposição')
             )
         )
         super(ReceberProposicaoForm, self).__init__(*args, **kwargs)
@@ -113,7 +113,7 @@ class MateriaSimplificadaForm(ModelForm):
             Fieldset(
                 _('Formulário Simplificado'),
                 row1, row2, row3, row4, row5,
-                form_actions(save_label='Salvar')
+                form_actions(label='Salvar')
             )
         )
         super(MateriaSimplificadaForm, self).__init__(*args, **kwargs)
@@ -151,7 +151,7 @@ class AcompanhamentoMateriaForm(ModelForm):
         row1 = to_row([('email', 10)])
 
         row1.append(
-            Column(form_actions(save_label='Cadastrar'), css_class='col-md-2')
+            Column(form_actions(label='Cadastrar'), css_class='col-md-2')
         )
 
         self.helper = FormHelper()
@@ -602,7 +602,7 @@ class MateriaLegislativaFilterSet(django_filters.FilterSet):
                      HTML(autor_label),
                      HTML(autor_modal),
                      row4, row5, row6, row7, row8, row9, row10,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
     @property
@@ -689,7 +689,7 @@ class AutoriaForm(ModelForm):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             Fieldset(_('Autoria'),
-                     row1, 'data_relativa', form_actions(save_label='Salvar')))
+                     row1, 'data_relativa', form_actions(label='Salvar')))
 
         if not kwargs['instance']:
             self.fields['autor'].choices = []
@@ -747,7 +747,7 @@ class AutoriaMultiCreateForm(Form):
         self.helper.layout = Layout(
             Fieldset(
                 _('Autorias'), row1, row2, 'data_relativa', 'autores',
-                form_actions(save_label='Incluir Autores Selecionados')))
+                form_actions(label='Incluir Autores Selecionados')))
 
         self.fields['autor'].choices = []
 
@@ -792,7 +792,7 @@ class AcessorioEmLoteFilterSet(django_filters.FilterSet):
         self.form.helper.form_method = 'GET'
         self.form.helper.layout = Layout(
             Fieldset(_('Documentos Acessórios em Lote'),
-                     row1, row2, form_actions(save_label='Pesquisar')))
+                     row1, row2, form_actions(label='Pesquisar')))
 
 
 class PrimeiraTramitacaoEmLoteFilterSet(django_filters.FilterSet):
@@ -824,7 +824,7 @@ class PrimeiraTramitacaoEmLoteFilterSet(django_filters.FilterSet):
         self.form.helper.form_method = 'GET'
         self.form.helper.layout = Layout(
             Fieldset(_('Primeira Tramitação'),
-                     row1, row2, form_actions(save_label='Pesquisar')))
+                     row1, row2, form_actions(label='Pesquisar')))
 
 
 class TramitacaoEmLoteFilterSet(django_filters.FilterSet):
@@ -865,7 +865,7 @@ class TramitacaoEmLoteFilterSet(django_filters.FilterSet):
         self.form.helper.form_method = 'GET'
         self.form.helper.layout = Layout(
             Fieldset(_('Tramitação em Lote'),
-                     row1, row2, form_actions(save_label='Pesquisar')))
+                     row1, row2, form_actions(label='Pesquisar')))
 
 
 class TipoProposicaoForm(ModelForm):
@@ -1303,8 +1303,12 @@ class ConfirmarProposicaoForm(ProposicaoForm):
             if self.proposicao_incorporacao_obrigatoria != 'N':
                 itens_incorporacao.append(to_column(('numero_de_paginas', 4)))
 
-        itens_incorporacao.append(to_column((FormActions(Submit(
-            'incorporar', _('Incorporar'), css_class='pull-right')), 12)))
+        itens_incorporacao.append(
+            to_column(
+                (form_actions(label=_('Incorporar'),
+                              name='incorporar'), 12)
+            )
+        )
 
         fields.append(
             Fieldset(_('Registro de Incorporação'), *itens_incorporacao))
@@ -1313,10 +1317,14 @@ class ConfirmarProposicaoForm(ProposicaoForm):
             Fieldset(
                 _('Registro de Devolução'),
                 to_column(('justificativa_devolucao', 12)),
-                to_column((FormActions(Submit(
-                    'devolver', _('Devolver'),
-                    css_class='btn-danger pull-right')), 12))
-            ))
+                to_column(
+                    (form_actions(label=_('Devolver'),
+                                  name='devolver',
+                                  css_class='btn-danger pull-right'), 12)
+                )
+            )
+        )
+
         self.helper = FormHelper()
         self.helper.layout = Layout(*fields)
 
@@ -1662,7 +1670,7 @@ class EtiquetaPesquisaForm(forms.Form):
             Fieldset(
                 ('Formulário de Etiqueta'),
                 row1, row2,
-                form_actions(save_label='Pesquisar')
+                form_actions(label='Pesquisar')
             )
         )
 
@@ -1730,7 +1738,7 @@ class FichaPesquisaForm(forms.Form):
             Fieldset(
                 ('Formulário de Ficha'),
                 row1,
-                form_actions(save_label='Pesquisar')
+                form_actions(label='Pesquisar')
             )
         )
 
@@ -1764,6 +1772,6 @@ class FichaSelecionaForm(forms.Form):
             Fieldset(
                 ('Selecione a ficha que deseja imprimir'),
                 row1,
-                form_actions(save_label='Gerar Impresso')
+                form_actions(label='Gerar Impresso')
             )
         )

--- a/sapl/norma/forms.py
+++ b/sapl/norma/forms.py
@@ -72,7 +72,7 @@ class NormaFilterSet(django_filters.FilterSet):
         self.form.helper.layout = Layout(
             Fieldset(_('Pesquisa de Norma'),
                      row1, row2, row3,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 

--- a/sapl/parlamentares/forms.py
+++ b/sapl/parlamentares/forms.py
@@ -298,7 +298,7 @@ class VotanteForm(ModelForm):
         self.helper = FormHelper()
         self.helper.layout = Layout(
             Fieldset(_('Votante'),
-                     row1, form_actions(save_label='Salvar'))
+                     row1, form_actions(label='Salvar'))
         )
         super(VotanteForm, self).__init__(*args, **kwargs)
 

--- a/sapl/protocoloadm/forms.py
+++ b/sapl/protocoloadm/forms.py
@@ -123,7 +123,7 @@ class ProtocoloFilterSet(django_filters.FilterSet):
                      HTML(autor_label),
                      HTML(autor_modal),
                      row4, row5, row6,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -194,7 +194,7 @@ class DocumentoAdministrativoFilterSet(django_filters.FilterSet):
             Fieldset(_('Pesquisar Documento'),
                      row1, row2,
                      row3, row4, row5,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -276,7 +276,7 @@ class AnularProcoloAdmForm(ModelForm):
                      row1,
                      row2,
                      HTML("&nbsp;"),
-                     form_actions(save_label='Anular')
+                     form_actions(label='Anular')
                      )
         )
         super(AnularProcoloAdmForm, self).__init__(
@@ -339,7 +339,7 @@ class ProtocoloDocumentForm(ModelForm):
                      row4,
                      row5,
                      HTML("&nbsp;"),
-                     form_actions(save_label=_('Protocolar Documento'))
+                     form_actions(label=_('Protocolar Documento'))
                      )
         )
         super(ProtocoloDocumentForm, self).__init__(
@@ -407,7 +407,7 @@ class ProtocoloMateriaForm(ModelForm):
         self.helper.layout = Layout(
             Fieldset(_('Identificação da Matéria'),
                      row1, row3,
-                     row4, form_actions(save_label='Protocolar Matéria')))
+                     row4, form_actions(label='Protocolar Matéria')))
 
         super(ProtocoloMateriaForm, self).__init__(
             *args, **kwargs)

--- a/sapl/sessao/forms.py
+++ b/sapl/sessao/forms.py
@@ -300,7 +300,7 @@ class SessaoPlenariaFilterSet(django_filters.FilterSet):
         self.form.helper.layout = Layout(
             Fieldset(self.titulo,
                      row1,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -376,7 +376,7 @@ class AdicionarVariasMateriasFilterSet(MateriaLegislativaFilterSet):
                      HTML(autor_label),
                      HTML(autor_modal),
                      row4, row5, row6, row7, row8, row9,
-                     form_actions(save_label='Pesquisar'))
+                     form_actions(label='Pesquisar'))
         )
 
 
@@ -467,7 +467,7 @@ class ResumoOrdenacaoForm(forms.Form):
             Fieldset(_(''),
                      row1, row2, row3, row4, row5,
                      row6, row7, row8, row9, row10,
-                     form_actions(save_label='Atualizar'))
+                     form_actions(label='Atualizar'))
         )
 
     def clean(self):


### PR DESCRIPTION
(para contextualização consulte a issue)
Só existe um jeito de a incorporação gerar a matéria 1564, existe a 1563 na base ([veja isto](https://github.com/interlegis/sapl/blame/master/sapl/materia/forms.py#L1440-L1449))...
@edwardoliveira, um possível ocorrido para a duplicação não é o fato em si relatado mas um caso específico do botão Salvar (já resolvido pelo @marciomazza) mas, por que? explico, a solução que desativa o botão salvar foi para os casos (maioria) de usar a função `crispy_layout_mixin.form_actions`. Portanto, se esta função não é usada, como é o caso do botão `incorporar` e `devolver`, aquele mesmo problema do botão salvar ainda está presente... [veja aqui](https://github.com/interlegis/sapl/blob/0849e3b942df73d2f21a7f0f9031d949ad4960e4/sapl/materia/forms.py#L1109-L1122). Foi usado a classe trivial sem a a solução... 

Este PR dá flexibilidade para a função form_actions e usa-a na incorporação e devolução. Fiz uma checagem completa no sistema em busca do uso default da classe FormActions e, não existe mais outros locais que a usa diretamente com exceção da app compilacao. Quanto a esta, peço que não haja refatoração, deixando o duplo clique a cargo do javascript da solução. 

Acredito que o problema da issue se resume aos fatos apontados...
