### PR TITLE
Corrige erro na opção FECHAR VOTAÇÃO

### DIFF
--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -1823,10 +1823,10 @@ class VotacaoNominalAbstract(SessaoPermissionMixin):
             votacao.observacao = request.POST.get('observacao', None)
 
             if self.ordem:
-                votacao.materia_id = ordem.materia.id
+                votacao.materia_id = materia_votacao.materia.id
                 votacao.ordem_id = ordem_id
             elif self.expediente:
-                votacao.materia_id = expediente.materia.id
+                votacao.materia_id = materia_votacao.materia.id
                 votacao.expediente_id = expediente_id
 
             votacao.tipo_resultado_votacao = form.cleaned_data['resultado_votacao']
@@ -1840,11 +1840,11 @@ class VotacaoNominalAbstract(SessaoPermissionMixin):
                 if self.ordem:
                     voto_parlamentar = VotoParlamentar.objects.get_or_create(
                         parlamentar_id=parlamentar_id,
-                        ordem=ordem)[0]
+                        ordem=materia_votacao)[0]
                 elif self.expediente:
                     voto_parlamentar = VotoParlamentar.objects.get_or_create(
                         parlamentar_id=parlamentar_id,
-                        expediente=expediente)[0]
+                        expediente=materia_votacao)[0]
 
                 voto_parlamentar.voto = voto
                 voto_parlamentar.parlamentar_id = parlamentar_id
@@ -1863,11 +1863,11 @@ class VotacaoNominalAbstract(SessaoPermissionMixin):
             # votação
             if self.ordem:
                 VotoParlamentar.objects.filter(
-                    ordem=ordem,
+                    ordem=materia_votacao,
                     votacao__isnull=True).delete()
             elif self.expediente:
                 VotoParlamentar.objects.filter(
-                    expediente=expediente,
+                    expediente=materia_votacao,
                     votacao__isnull=True).delete()
             return self.form_valid(form)
 


### PR DESCRIPTION
Um commit anterior suprimiu as variáveis 'ordem' e 'expediente', porém ainda mantinha as referências a elas em outras partes do código. Este PR substitui essas ocorrências pela variável 'materia_votacao'.