### PR TITLE
Exibir impressão de etiqueta no protocolo

### DIFF
--- a/sapl/templates/protocoloadm/protocolo_mostrar.html
+++ b/sapl/templates/protocoloadm/protocolo_mostrar.html
@@ -2,9 +2,12 @@
 {% load i18n %}
 {% load tz %}
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block detail_content %}
-	<strong>Protocolo: </strong>{{ protocolo.numero|stringformat:'06d' }}/{{ protocolo.ano }}</br>
+        <strong>Protocolo: </strong>{{ protocolo.numero|stringformat:'06d' }}/{{ protocolo.ano }} - 
+        <a href="{% url 'sapl.relatorios:relatorio_etiqueta_protocolo' protocolo.numero protocolo.ano %}"><img src="{% static 'img/etiqueta.png' %}" alt="Etiqueta Individual"></a></br>
+
 	<strong>Assunto: </strong> {{ protocolo.assunto_ementa|default:"Não informado" }}</br>
 	<strong>Data Protocolo: </strong> {{ protocolo.data|date:"d/m/Y" }} - Horário: {{ protocolo.timestamp|localtime|date:"H:i" }}</br>
 


### PR DESCRIPTION
A impressão da etiqueta está disponível apenas na lista de consultas aos protocolos. Este PR disponibiliza o link na visualização do protocolo (protocolo-mostrar). Esta tela, inclusive, é a tela que aparece quando da criação do protocolo, de modo que facilita o procedimento do operador. Além disso, replica o funcionamento do SAPL 2.5, que possibilita a impressão da etiqueta assim que o protocolo é gerado.