### PR TITLE
Link para o arquivo do documento administrativo no resultado da pesquisa

### DIFF
--- a/sapl/templates/protocoloadm/documentoadministrativo_filter.html
+++ b/sapl/templates/protocoloadm/documentoadministrativo_filter.html
@@ -39,11 +39,14 @@
               <strong><a href="{% url 'sapl.protocoloadm:documentoadministrativo_detail' d.id %}">{{d.tipo.sigla}} {{d.numero}}/{{d.ano}} - {{d.tipo}}</strong></a></br>
               <strong>Interessado:</strong>&nbsp;{{ d.interessado|default_if_none:"Não informado"}}</br>
               <strong>Assunto:</strong>&nbsp;{{ d.assunto|safe }}</br>
-
               {% if d.protocolo %}
                 <strong>Protocolo:</strong>&nbsp;<a href="{% url 'sapl.protocoloadm:protocolo_mostrar' d.protocolo.id %}">{{ d.protocolo}}</a></br>
               {% endif %}
+              {% if d.texto_integral %}
+                <strong><a href="{{ d.texto_integral.url }}">Texto Integral</a></strong></br>
+              {% endif %}
             </td>
+
           </tr>
         {% endfor %}
       {% else  %}

--- a/sapl/templates/protocoloadm/layouts.yaml
+++ b/sapl/templates/protocoloadm/layouts.yaml
@@ -4,7 +4,7 @@ TipoDocumentoAdministrativo:
   - sigla:4  descricao
 
 DocumentoAdministrativo:
-  {% trans 'Indentificação Básica' %}:
+  {% trans 'Identificação Básica' %}:
   - tipo  numero  ano
   - data  protocolo 
   - assunto


### PR DESCRIPTION
Alteração solicitada por usuário com perfil de operador administrativo aqui da Câmara, alegando que tal situação facilita a visualização dos registros que estão ou não com o documento administrativo anexado. Tal funcionamento é observado no SAPL 2.5.