### PR TITLE
Votação simbólica default em Matérias do Expediente e Ordem do Dia

### DIFF
--- a/sapl/sessao/models.py
+++ b/sapl/sessao/models.py
@@ -241,7 +241,7 @@ class AbstractOrdemDia(models.Model):
     numero_ordem = models.PositiveIntegerField(verbose_name=_('Nº Ordem'))
     resultado = models.TextField(blank=True, verbose_name=_('Resultado'))
     tipo_votacao = models.PositiveIntegerField(
-        verbose_name=_('Tipo de votação'), choices=TIPO_VOTACAO_CHOICES)
+        verbose_name=_('Tipo de votação'), choices=TIPO_VOTACAO_CHOICES, default=1)
     votacao_aberta = models.NullBooleanField(
         blank=True,
         choices=YES_NO_CHOICES,


### PR DESCRIPTION
Ao cadastrar uma matéria na ordem do dia ou expediente, vai trazer preenchido o campo tipo de votação com o valor 'Simbólica', considerando que esta é a situação da grande maioria das matérias que vão a plenário. Tal providência facilita a inserção das matérias, principalmente se há grande quantidade a ser cadastrada.