### PR TITLE
Exibe assunto e interessado no comprovante se protocolo administrativo

### DIFF
--- a/sapl/templates/protocoloadm/comprovante.html
+++ b/sapl/templates/protocoloadm/comprovante.html
@@ -70,6 +70,15 @@
 				<th>Autor</th>
 				<td>{{ protocolo.autor }}</td>
 			</tr>
+                {% else %}
+                        <tr>   
+                                <th>Assunto</th>
+                                <td>{{ protocolo.assunto_ementa }}</td>
+                        </tr>
+                        <tr>
+                                <th>Interessado</th>
+                                <td>{{ protocolo.interessado }}</td>
+                        </tr>
 		{% endif %}
 		<tr>
 			<th>Natureza</th>


### PR DESCRIPTION
Quando o tipo de protocolo é Legislativo, o SAPL imprime no comprovante a Ementa e o Autor. Para o protocolo Administrativo, os campos equivalentes são Assunto e Interessado, porém não constavam no comprovante.