### PR TITLE
Exibição da Mesa Diretora e ajustes de preenchimento em matérias e protocolo

### DIFF
--- a/sapl/parlamentares/views.py
+++ b/sapl/parlamentares/views.py
@@ -650,7 +650,7 @@ class MesaDiretoraView(FormView):
         sessao_atual = sessoes.filter(data_inicio__year__lte=year).exclude(
             data_inicio__gt=timezone.now()).order_by('-data_inicio').first()
 
-        mesa = sessao_atual.composicaomesa_set.all() if sessao_atual else []
+        mesa = sessao_atual.composicaomesa_set.all().order_by('cargo_id') if sessao_atual else []
 
         cargos_ocupados = [m.cargo for m in mesa]
         cargos = CargoMesa.objects.all()
@@ -710,7 +710,7 @@ def altera_field_mesa(request):
 
     # Atualiza os componentes da view após a mudança
     composicao_mesa = ComposicaoMesa.objects.filter(
-        sessao_legislativa=sessao_selecionada)
+        sessao_legislativa=sessao_selecionada).order_by('cargo_id')
 
     cargos_ocupados = [m.cargo for m in composicao_mesa]
     cargos = CargoMesa.objects.all()
@@ -879,7 +879,7 @@ def altera_field_mesa_public_view(request):
     lista_sessoes = [(s.id, s.__str__()) for s in sessoes]
 
     composicao_mesa = ComposicaoMesa.objects.filter(
-        sessao_legislativa=sessao_selecionada)
+        sessao_legislativa=sessao_selecionada).order_by('cargo_id')
 
     cargos_ocupados = [(m.cargo.id,
                         m.cargo.__str__()) for m in composicao_mesa]

--- a/sapl/protocoloadm/forms.py
+++ b/sapl/protocoloadm/forms.py
@@ -291,7 +291,8 @@ class ProtocoloDocumentForm(ModelForm):
 
     tipo_protocolo = forms.ChoiceField(required=True,
                                        label=_('Tipo de Protocolo'),
-                                       choices=TIPOS_PROTOCOLO_CREATE,)
+                                       choices=TIPOS_PROTOCOLO_CREATE,
+                                       initial=0,)
 
     tipo_documento = forms.ModelChoiceField(
         label=_('Tipo de Documento'),

--- a/sapl/sessao/models.py
+++ b/sapl/sessao/models.py
@@ -241,7 +241,7 @@ class AbstractOrdemDia(models.Model):
     numero_ordem = models.PositiveIntegerField(verbose_name=_('Nº Ordem'))
     resultado = models.TextField(blank=True, verbose_name=_('Resultado'))
     tipo_votacao = models.PositiveIntegerField(
-        verbose_name=_('Tipo de votação'), choices=TIPO_VOTACAO_CHOICES)
+        verbose_name=_('Tipo de votação'), choices=TIPO_VOTACAO_CHOICES, default=1)
     votacao_aberta = models.NullBooleanField(
         blank=True,
         choices=YES_NO_CHOICES,

--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -987,7 +987,7 @@ class MesaView(FormMixin, DetailView):
 
             return self.render_to_response(context)
 
-        mesa = sessao.integrantemesa_set.all() if sessao else []
+        mesa = sessao.integrantemesa_set.all().order_by('cargo_id') if sessao else []
         cargos_ocupados = [m.cargo for m in mesa]
         cargos = CargoMesa.objects.all()
         cargos_vagos = list(set(cargos) - set(cargos_ocupados))
@@ -1038,7 +1038,7 @@ def atualizar_mesa(request):
 
     # Atualiza os componentes da view após a mudança
     composicao_mesa = IntegranteMesa.objects.filter(
-        sessao_plenaria=sessao.id)
+        sessao_plenaria=sessao.id).order_by('cargo_id')
 
     cargos_ocupados = [m.cargo for m in composicao_mesa]
     cargos = CargoMesa.objects.all()


### PR DESCRIPTION
1) Ajusta a exibição da Mesa Diretora da Legislatura e da Sessão Plenária por ordem de cargo e não de inserção;
2) Na tela Adicionar Matéria à Ordem do Dia ou ao Expediente, preenche o tipo de votação com "Simbólica", já que este é o tipo da grande maioria de votação das matérias. Além disso, pelo menos aqui em nossa Câmara, o pedido para votação nominal ocorre durante a sessão, quando a matéria já está cadastrada;
3) Na tela Protocolar Documento, trás preenchido o campo Tipo de Protocolo como recebido, também por ser a grande maioria dos casos.