### PR TITLE
Ajusta ordenação em proposições não recebidas

### DIFF
--- a/sapl/base/templatetags/common_tags.py
+++ b/sapl/base/templatetags/common_tags.py
@@ -64,6 +64,16 @@ def sort_by_keys(value, key):
 
 
 @register.filter
+def paginacao_limite_inferior(pagina):
+    return (int(pagina) - 1) * 10 
+
+
+@register.filter
+def paginacao_limite_superior(pagina):
+    return int(pagina) * 10
+
+
+@register.filter
 def lookup(d, key):
     return d[key] if key in d else []
 

--- a/sapl/materia/views.py
+++ b/sapl/materia/views.py
@@ -426,6 +426,10 @@ class ProposicaoPendente(PermissionRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(ProposicaoPendente, self).get_context_data(**kwargs)
+        context['object_list'] = Proposicao.objects.filter(
+            data_envio__isnull=False,
+            data_recebimento__isnull=True,
+            data_devolucao__isnull=True)
         paginator = context['paginator']
         page_obj = context['page_obj']
         context['AppConfig'] = sapl.base.models.AppConfig.objects.all().last()
@@ -434,6 +438,8 @@ class ProposicaoPendente(PermissionRequiredMixin, ListView):
         context['NO_ENTRIES_MSG'] = 'Nenhuma proposição pendente.'
 
         context['subnav_template_name'] = 'materia/subnav_prop.yaml'
+        qr = self.request.GET.copy()
+        context['filter_url'] = ('&o=' + qr['o']) if 'o' in qr.keys() else ''
         return context
 
 

--- a/sapl/templates/materia/prop_pendentes_list.html
+++ b/sapl/templates/materia/prop_pendentes_list.html
@@ -39,24 +39,33 @@
               {% define object_list as list %}
           {% endif %}
 
+          {% if 'page' in request.GET %}
+                {% define request.GET.page as pagina %}
+          {% else %}
+                {% define '1' as pagina %}
+          {% endif %}
+
           {% for prop in list %}
-            <tr>
-              <td>
-                 <a href="{% url 'sapl.materia:proposicao_detail' prop.pk %}">{{ prop.data_envio|localtime|date:"d/m/Y H:i:s" }}</a>
-              </td>
-              <td>{{ prop.tipo.descricao }}</td>
-              <td>{{ prop.descricao }}</td>
-              <td>{{ prop.autor }}</td>
-              <td>
-                {% if not AppConfig.receber_recibo_proposicao %}
-                  {%if prop.hash_code %}
-                    <a href="{% url 'sapl.materia:proposicao-confirmar' prop.hash_code|strip_hash prop.pk %}">{{ prop.hash_code }}</a>
-                  {% else %}
-                    {{ prop.hash_code }}
+
+            {% if forloop.counter > pagina|paginacao_limite_inferior and forloop.counter <= pagina|paginacao_limite_superior %}
+              <tr>
+                <td>
+                   <a href="{% url 'sapl.materia:proposicao_detail' prop.pk %}">{{ prop.data_envio|localtime|date:"d/m/Y H:i:s" }}</a>
+                </td>
+                <td>{{ prop.tipo.descricao }}</td>
+                <td>{{ prop.descricao }}</td>
+                <td>{{ prop.autor }}</td>
+                <td>
+                  {% if not AppConfig.receber_recibo_proposicao %}
+                    {%if prop.hash_code %}
+                      <a href="{% url 'sapl.materia:proposicao-confirmar' prop.hash_code|strip_hash prop.pk %}">{{ prop.hash_code }}</a>
+                    {% else %}
+                      {{ prop.hash_code }}
+                    {% endif %}
                   {% endif %}
-                {% endif %}
-              </td>
-             </tr>
+                </td>
+               </tr>
+             {% endif %}
           {% endfor %}
         </tbody>
       </table>


### PR DESCRIPTION
Na tela de Proposições Não Recebidas - visão do operador - a opção de ordenação por algum campo do cabeçalho não está sendo respeitada no caso de haver paginação (10 proposições por página). São exibidos na ordem escolhida apenas os registros que estão na primeira tela, e caso o operador navegue para as demais páginas, a ordem de exibição retorna para a inicial do sistema.