### PR TITLE
Tela de confirmação para retornar proposição enviada

### DIFF
--- a/sapl/materia/urls.py
+++ b/sapl/materia/urls.py
@@ -24,7 +24,7 @@ from sapl.materia.views import (AcompanhamentoConfirmarView,
                                 TipoProposicaoCrud, TramitacaoCrud,
                                 TramitacaoEmLoteView, UnidadeTramitacaoCrud,
                                 proposicao_texto, recuperar_materia,
-                                ExcluirTramitacaoEmLoteView)
+                                ExcluirTramitacaoEmLoteView, RetornarProposicao)
 from sapl.norma.views import NormaPesquisaSimplesView
 
 from .apps import AppConfig
@@ -120,6 +120,8 @@ urlpatterns_proposicao = [
 
     url(r'^proposicao/texto/(?P<pk>\d+)$', proposicao_texto,
         name='proposicao_texto'),
+    url(r'^proposicao/(?P<pk>\d+)/retornar', RetornarProposicao.as_view(),
+        name='retornar-proposicao'),
 ]
 
 urlpatterns_sistema = [

--- a/sapl/materia/views.py
+++ b/sapl/materia/views.py
@@ -509,6 +509,31 @@ class ReceberProposicao(PermissionRequiredForAppCrudMixin, FormView):
         return context
 
 
+class RetornarProposicao(UpdateView):
+    app_label = sapl.protocoloadm.apps.AppConfig.label
+    template_name = "materia/proposicao_confirm_return.html"
+    model = Proposicao
+    fields = ['data_envio', 'descricao' ]
+    permission_required = ('materia.detail_proposicao_enviada', )
+
+    def dispatch(self, request, *args, **kwargs):
+
+        try:
+            p = Proposicao.objects.get(id=kwargs['pk'])
+        except:
+            raise Http404()
+
+        if p.autor.user != request.user:
+             messages.error(
+                 request,
+                 'Usuário sem acesso a esta opção.' % 
+                     request.user)
+             return redirect('/')
+
+        return super(RetornarProposicao, self).dispatch(
+            request, *args, **kwargs)
+
+
 class ConfirmarProposicao(PermissionRequiredForAppCrudMixin, UpdateView):
     app_label = sapl.protocoloadm.apps.AppConfig.label
     template_name = "materia/confirmar_proposicao.html"

--- a/sapl/templates/materia/proposicao_confirm_return.html
+++ b/sapl/templates/materia/proposicao_confirm_return.html
@@ -1,0 +1,27 @@
+{% extends "crud/detail.html" %}
+{% load i18n %}
+
+{% block sections_nav %}{% endblock sections_nav %}
+    {% block title %}
+       <h1 class="page-header">
+          {{ object|safe|linebreaksbr }}
+       </h1>
+    {% endblock %}
+{% block base_content %}
+  <form action="" method="post">{% csrf_token %}
+    <br>
+    <div class="panel panel-danger">
+      <div class="panel-heading  text-center">
+        {% blocktrans %}
+          ATENÇÃO: Retornar a proposição cancela o envio da mesma para protocolo e invalida o recibo já emitido.<br />
+          Será necessário novo envio e impressão de novo recibo para recebimento pela Casa Legislativa.<br />
+          Confirma retorno da proposição para o Parlamentar/Gabinete?
+        {% endblocktrans %}<br>
+      </div>
+      <div class="panel-body text-center">
+        <a href="{% url 'sapl.materia:proposicao_detail' object.pk %}" class="btn btn-inverse">{% trans 'Cancelar'  %}</a>
+        <a href="{% url 'sapl.materia:proposicao_detail' object.pk %}?action=return" class="btn btn-default btn-excluir">{% trans 'Confirmar' %}</a>
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/sapl/templates/materia/proposicao_detail.html
+++ b/sapl/templates/materia/proposicao_detail.html
@@ -21,7 +21,7 @@
         <div class="actions btn-group" role="group">
           <a class="btn btn-default" onclick="window.open('{% url 'sapl.materia:recibo-proposicao' object.pk %}','Recibo','width=1100, height=600, scrollbars=yes')">{% trans "Recibo de Envio" %}</a>
           {% if not object.data_recebimento %}
-            <a href="{{ view.detail_url }}?action=return" class="btn btn-default btn-excluir">{% trans 'Retornar Proposição Enviada' %}</a>
+            <a href="{% url 'sapl.materia:retornar-proposicao' object.pk %}" class="btn btn-default btn-excluir">{% trans 'Retornar Proposição Enviada' %}</a>
           {% endif %}
         </div>
       {% endblock %}


### PR DESCRIPTION
A opção de Retornar Proposição Enviada, disponível para o parlamentar, não exibe tela de confirmação, apenas na tela de detalhe da proposição uma mensagem de proposição retornada com sucesso.
Em mais de um caso, tivemos demandas dos gabinetes e da secretaria porque a proposição não aparecia para ser recebida, havendo impressão do recibo. Na verdade, foram indevidamente retornados.
O presente PR insere uma tela de confirmação como segue:

![tela de confirmacao](https://user-images.githubusercontent.com/22030378/44341936-ffd54d80-a478-11e8-91d7-373319b6830f.png)

Dessa forma, minimiza-se o retorno acidental de proposições.