### PR TITLE
impl redirect para iframe incorreto

### DIFF
--- a/sapl/static/styles/app.scss
+++ b/sapl/static/styles/app.scss
@@ -558,6 +558,19 @@ p {
   }
 }
 
+.btn-cancel-iframe {
+  position: relative;
+  text-align: right;
+  opacity: 0.5;
+  &:hover {
+    opacity: 1;
+  }
+  a {
+    padding: 10px;
+    display: inline-block;
+  }
+}
+
 
 @media (max-width: 1199px) {
   .masthead {

--- a/sapl/templates/base.html
+++ b/sapl/templates/base.html
@@ -29,6 +29,7 @@
 
   <body>
     <div class="page fadein">
+    	
       {% if not request|has_iframe %}
       {% block navigation %}
       <nav class="navbar navbar-inverse navbar-static-top">
@@ -108,6 +109,9 @@
       </header>
       {% endblock main_header %}
       {% else %}
+              <div class="btn-cancel-iframe">
+                <a href="?iframe=0" target="_blank"><i class="fa fa-2x fa-arrows-alt"></i></a>
+              </div>
               <header class="masthead">
                 <div class="container">
                   <div class="hidden-print">
@@ -244,6 +248,25 @@
       <script type="text/javascript" src="{% static 'jquery-query-object/jquery.query-object.js' %}"></script>
 
       {% block extra_js %}{% endblock %}
+
+      <script type="text/javascript" >
+
+      
+        function inIframe () {
+          try {
+              return window.self !== window.top;
+          } catch (e) {
+              return true;
+          }
+        }
+        $(document).ready(function(){
+          let iframe_set_backend = {{ request|has_iframe|lower }}
+          if (iframe_set_backend && !inIframe() ) {
+            let href = location.href
+            location.href = href + '?iframe=0'
+          }          
+        });
+      </script>
 
     {% endblock foot_js %}
   </body>


### PR DESCRIPTION
Implementa redirect via java script para teste do iframe=0 ou 1... redirecionando o navegador para iframe=0 se o sapl não estiver rodando dentro de um iframe. Secundariamente adiciona botão para expansão manual para abertura em outra janela.

foram feitos teste locais, rodando o Sapl como iframe dentro de outra solução... favor validar a efetividade da proposta dentro do PortalModelo