### PR TITLE
Adiciona documentos do Git Community

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--- Forneça um resumo geral da _issue_ no título acima -->
+
+## Comportamento Esperado
+<!--- Se você está descrevendo um _bug_, conte-nos o que deveria acontecer. -->
+<!--- Se você está sugerindo uma mudança/melhoria, conte-nos como deve funcionar. -->
+
+## Comportamento Atual
+<!--- Se está descrevendo um bug, conte-nos o que acontece em vez do comportamento esperado. -->
+<!--- Se está sugerindo uma mudança/melhoria, explique a diferença com o comportamento atual. -->
+
+## Possível Solução
+<!--- Não é obrigatório, mas sugira uma possível correção/razão para o bug -->
+<!--- ou ideias de como implementar a adição/mudança. -->
+
+## Passos para Reproduzir (para bugs)
+<!--- Forneça um link para um exemplo, ou um conjunto de passos inequívocos -->
+<!--- para reproduzir esse bug. Inclua código para reproduzir, se relevante. -->
+1.
+2.
+3.
+4.
+
+## Contexto
+<!--- Como esse problema o afeta? O que você está tentando realizar? -->
+<!--- Fornecer o contexto nos ajuda a encontrar uma solução que seja mais útil no mundo real -->
+
+## Imagens do Ocorrido
+<!--- Representação visual em vídeo ou imagem do ocorrido -->
+<!--- Se está descrevendo um bug poste imagens ou vídeos na repordução do bug citado, caso se aplique --:
+
+## Seu Ambiente
+<!--- Inclua detalhes relevantes sobre o ambiente em que você presenciou/experienciou o bug. -->
+* Versão usada (_Release_):
+* Nome e versão do navegador:
+* Nome e versão do Sistema Operacional (desktop ou mobile):
+* Link para o seu projeto (Caso de fork deste projeto):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--- Forneça um resumo geral das suas alterações no título acima -->
+
+## Descrição
+<!--- Decreva suas alterações detalhadamente -->
+
+## _Issue_ Relacionada
+<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
+<!--- Se está sugerindo uma nova _feature_ ou mudança, por favor discuta em uma _issue_ antes. -->
+<!--- Se está corrigindo um _bug_, deve haver uma _issue_ descrevendo-o com passos para reproduzir. -->
+<!--- Por favor, adicione o link para a _issue_ aqui: -->
+
+## Motivação e Contexto
+<!--- Por que essa mudança é necessária? Qual problema ela resolve? -->
+
+## Como Isso Foi Testado?
+<!--- Por favor, descreva detalhadamente como você testou suas mudanças. -->
+<!--- Inclua detalhes do seu ambiente de teste e os testes que você executou -->
+<!--- para ver como a sua alteração afeta outras áreas do código, etc. -->
+
+## Capturas de Tela (se apropriado):
+<!--- Insera imagens, se apropriado, da adição e/ou correção que foi feita -->
+
+## Tipos de Mudanças
+<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
+- [ ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
+- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
+- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)
+
+## Checklist:
+<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
+<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
+- [ ] Eu li o documento de Contribuição (**CONTRIBUTING**).
+- [ ] Meu código segue o estilo de código desse projeto.
+- [ ] Minha alteração requer uma alteração na documentação.
+- [ ] Eu atualizei a documentação de acordo.
+- [ ] Eu adicionei testes para cobrir minhas mudanças.
+- [ ] Todos os testes novos e existentes passaram.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Código de Conduta do Convênio de Contribuição
+
+## Nosso Compromisso
+No interesse de promover um ambiente aberto e acolhedor, nós, como colaboradores e mantenedores, prometemos fazer parte de nosso projeto e de nossa comunidade uma experiência livre de assédio para todos, independentemente da idade, tamanho corporal, deficiência, etnia, identidade e expressão de gênero, nível de experiência, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexual.
+
+## Nossos Padrões
+Exemplos de comportamentos que contribuem para criar um ambiente positivo incluem:
+
+- Uso linguagem acolhedora e inclusiva.
+- Ser respeitoso com diferentes pontos de vista e experiências.
+- Aceitar críticas construtivas.
+- Concentrar no que é melhor para a comunidade.
+- Mostrar empatia para com outros membros da comunidade.
+
+Exemplos de comportamentos inaceitáveis dos contribuidores incluem:
+
+- O uso de linguagem ou imagens sexualizadas e avanços ou assédios sexuais indesejáveis.
+- Comentários depreciativos, insultos/derrogatórios e ataques pessoais ou políticos.
+- Assédio público ou em privado.
+- Publicar a informação privada dos outros, como um endereço físico ou eletrônico, sem permissão explícita.
+- Outra conduta que razoavelmente pode ser considerada inapropriada em um ambiente profissional.
+
+## Nossas Responsabilidades
+Os responsáveis ​​pelo projeto são responsáveis ​​por esclarecer os padrões de comportamento aceitável e devem tomar medidas corretivas apropriadas e justas em resposta a qualquer instância de comportamento inaceitável.
+
+Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, compromissos, códigos, edições de wiki, problemas e outras contribuições que não estejam alinhados com este Código de Conduta ou proibir temporariamente ou permanentemente qualquer contribuinte para outros comportamentos que eles consideram inapropriado, ameaçador, ofensivo ou prejudicial.
+
+## Escopo
+Este Código de Conduta aplica-se tanto nos espaços do projeto quanto nos espaços públicos quando um indivíduo representa o projeto ou sua comunidade. Exemplos de representar um projeto ou comunidade incluem o uso de um endereço de e-mail oficial do projeto, postagem através de uma conta oficial em mídias sociais, ou atuando como representante designado em um evento online ou offline. A representação de um projeto pode ser melhor definida e esclarecida pelos responsáveis ​​pelo projeto.
+
+## Execução
+Instâncias de comportamento abusivo, de assédio ou de outra forma inaceitável podem ser comunicadas ao contactar a equipe do projeto através do COLAB do Interlegis para o projeto do SAPL, todas as informações podem ser acessadas através [deste link](https://colab.interlegis.leg.br/wiki/ProjetoSapl).
+A equipe do projeto irá rever e investigar todas as queixas, e responderá da forma que julgar apropriada às circunstâncias.
+A equipe do projeto buscará manter a confidencialidade em relação ao repórter de um incidente. Mais detalhes sobre políticas de execução específicas podem ser publicados separadamente.
+
+Os mantenedores do projeto que não seguem ou aplicam o Código de Conduta de boa fé podem enfrentar repercussões temporárias ou permanentes, conforme determinado por outros membros da liderança do projeto.
+
+
+## Atribuição
+Este Código de Conduta é adaptado da Convenção do Contribuinte, versão 1.4, disponível em <a>http://contributor-covenant.org/version/1/4</a>.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contribuindo com SAPL
+
+Caso queira contribuir com o projeto, talvez seja uma boa ideia começar pelo [README](https://github.com/interlegis/sapl) para conhecer melhor sobre nós.
+Outro documento importante e que deve ser lido é o [Código de Conduta](https://github.com/interlegis/sapl/blob/3.1.x/docs/CODE_OF_CONDUCT.md).
+
+Obrigado por contribuir! :tada::+1: Sua ajuda será recebida com muita gratidão!
+
+
+# Como eu posso contribuir?
+
+## Reportando um Bug
+
+* Esse projeto segue um padrão de [_Issues_](https://github.com/interlegis/sapl/blob/3.1.x/.github/ISSUE_TEMPLATE.md). Logo, caso encontre um bug, verifique se ele não se encontra em uma das nossas _Issues_. Os bugs devem ser marcados com _tag (label)_ __bug__.
+
+* Se o bug encontrado não consta nas _Issues_, basta abrir uma [Nova _Issue_](https://github.com/interlegis/sapl/issues/new).
+
+
+## Adicionando e/ou modificando alguma funcionalidade
+
+* Primeiro verifique que não existe nenhuma [_Issue_](https://github.com/interlegis/sapl/issues) a respeito dessa modificação e/ou adição.
+
+* Caso não exista, crie uma [Nova _Issue_](https://github.com/interlegis/sapl/issues/new). Dê um título significativo a ela, coloque uma descrição e pelo menos uma _label_.
+
+* As mudanças devem ser submetidas através de [_Pull Requests_](https://github.com/interlegis/sapl/compare). Você pode encontrar mais sobre isso no [_Pull Requests Template_](https://github.com/interlegis/sapl/blob/3.1.x/.github/PULL_REQUEST_TEMPLATE.md).


### PR DESCRIPTION
@edwardoliveira tomei a liberdade (mas acho que já tinha conversado sobre com você) de criar os documentos do git community, para que ficasse mais claro como as pessoas poderiam contribuir para o SAPL e, também, numa forma de organizar nosso git para ficar mais colaborativo. Esses docs são uma versão 0.0.1-alpha-WIP, mas acho válido levantar a discussão para melhorar o git do SAPL. 

### Adições

Adiciona os templates de Issue e Pull Request

Adiciona o Código de Conduta

Adiciona o documento de Contribuição
