### PR TITLE
Correção do Relatório de Matérias em Tramitação

### DIFF
--- a/sapl/base/forms.py
+++ b/sapl/base/forms.py
@@ -17,7 +17,7 @@ from django.utils.translation import string_concat
 from sapl.base.models import Autor, TipoAutor
 from sapl.crispy_layout_mixin import (SaplFormLayout, form_actions, to_column,
                                       to_row)
-from sapl.materia.models import MateriaLegislativa
+from sapl.materia.models import (MateriaLegislativa, UnidadeTramitacao, StatusTramitacao)
 from sapl.parlamentares.models import SessaoLegislativa
 from sapl.sessao.models import SessaoPlenaria
 from sapl.settings import MAX_IMAGE_UPLOAD_SIZE
@@ -671,14 +671,23 @@ class RelatorioMateriasTramitacaoilterSet(django_filters.FilterSet):
                                       label='Ano da Matéria',
                                       choices=RANGE_ANOS)
 
+    tramitacao__unidade_tramitacao_destino = django_filters.ModelChoiceFilter(
+        queryset=UnidadeTramitacao.objects.all(),
+        label=_('Unidade Atual'))
+
+    tramitacao__status = django_filters.ModelChoiceFilter(
+        queryset=StatusTramitacao.objects.all(),
+        label=_('Status Atual'))
+
     @property
     def qs(self):
         parent = super(RelatorioMateriasTramitacaoilterSet, self).qs
         return parent.distinct().order_by('-ano', 'tipo', '-numero')
 
+
     class Meta:
         model = MateriaLegislativa
-        fields = ['ano', 'tipo', 'tramitacao__unidade_tramitacao_local',
+        fields = ['ano', 'tipo', 'tramitacao__unidade_tramitacao_destino',
                   'tramitacao__status']
 
     def __init__(self, *args, **kwargs):
@@ -689,7 +698,7 @@ class RelatorioMateriasTramitacaoilterSet(django_filters.FilterSet):
 
         row1 = to_row([('ano', 12)])
         row2 = to_row([('tipo', 12)])
-        row3 = to_row([('tramitacao__unidade_tramitacao_local', 12)])
+        row3 = to_row([('tramitacao__unidade_tramitacao_destino', 12)])
         row4 = to_row([('tramitacao__status', 12)])
 
         self.form.helper = FormHelper()

--- a/sapl/base/views.py
+++ b/sapl/base/views.py
@@ -399,13 +399,13 @@ class RelatorioMateriasTramitacaoView(FilterView):
         qs = context['object_list']
         qs = qs.filter(em_tramitacao=True)
 
-        if 'tramitacao__unidade_tramitacao_destino' in qr and qr['tramitacao__unidade_tramitacao_destino'] != '' :
+        if qr.get('tramitacao__unidade_tramitacao_destino'):
             id_materias = []
             for item in qs:
                 if str(item.tramitacao_set.order_by('-id').first().unidade_tramitacao_destino_id) == qr['tramitacao__unidade_tramitacao_destino']:
                     id_materias.append(item.id)
             qs = qs.filter(em_tramitacao=True, id__in=id_materias)
-        if 'tramitacao__status' in qr and qr['tramitacao__status'] != '' :
+        if qr.get('tramitacao__status'):
             id_materias = []
             for item in qs:
                 if str(item.tramitacao_set.order_by('-id').first().status_id) == qr['tramitacao__status']:

--- a/sapl/base/views.py
+++ b/sapl/base/views.py
@@ -44,6 +44,17 @@ from .forms import (AlterarSenhaForm, CasaLegislativaForm,
 from .models import AppConfig, CasaLegislativa
 
 
+def filtra_url_materias_em_tramitacao(qr, qs, campo_url, local_ou_status):
+    id_materias = []
+    filtro_url = qr[campo_url]
+    if local_ou_status == 'local':
+        id_materias = [item.id for item in qs if item.tramitacao_set.order_by('-id').first().unidade_tramitacao_destino_id == int(filtro_url)]
+    elif local_ou_status == 'status':
+        id_materias = [item.id for item in qs if item.tramitacao_set.order_by('-id').first().status_id == int(filtro_url)]
+
+    return qs.filter(em_tramitacao=True, id__in=id_materias)
+
+
 def get_casalegislativa():
     return CasaLegislativa.objects.first()
 
@@ -400,17 +411,9 @@ class RelatorioMateriasTramitacaoView(FilterView):
         qs = qs.filter(em_tramitacao=True)
 
         if qr.get('tramitacao__unidade_tramitacao_destino'):
-            id_materias = []
-            for item in qs:
-                if str(item.tramitacao_set.order_by('-id').first().unidade_tramitacao_destino_id) == qr['tramitacao__unidade_tramitacao_destino']:
-                    id_materias.append(item.id)
-            qs = qs.filter(em_tramitacao=True, id__in=id_materias)
+            qs = filtra_url_materias_em_tramitacao(qr, qs, 'tramitacao__unidade_tramitacao_destino', 'local')
         if qr.get('tramitacao__status'):
-            id_materias = []
-            for item in qs:
-                if str(item.tramitacao_set.order_by('-id').first().status_id) == qr['tramitacao__status']:
-                    id_materias.append(item.id)
-            qs = qs.filter(em_tramitacao=True, id__in=id_materias)
+            qs = filtra_url_materias_em_tramitacao(qr, qs, 'tramitacao__status', 'status')
 
         context['object_list'] = qs
 

--- a/sapl/base/views.py
+++ b/sapl/base/views.py
@@ -395,8 +395,23 @@ class RelatorioMateriasTramitacaoView(FilterView):
 
         context['title'] = _('Matérias em Tramitação')
 
+        qr = self.request.GET.copy()
         qs = context['object_list']
         qs = qs.filter(em_tramitacao=True)
+
+        if 'tramitacao__unidade_tramitacao_destino' in qr and qr['tramitacao__unidade_tramitacao_destino'] != '' :
+            id_materias = []
+            for item in qs:
+                if str(item.tramitacao_set.order_by('-id').first().unidade_tramitacao_destino_id) == qr['tramitacao__unidade_tramitacao_destino']:
+                    id_materias.append(item.id)
+            qs = qs.filter(em_tramitacao=True, id__in=id_materias)
+        if 'tramitacao__status' in qr and qr['tramitacao__status'] != '' :
+            id_materias = []
+            for item in qs:
+                if str(item.tramitacao_set.order_by('-id').first().status_id) == qr['tramitacao__status']:
+                    id_materias.append(item.id)
+            qs = qs.filter(em_tramitacao=True, id__in=id_materias)
+
         context['object_list'] = qs
 
         qtdes = {}
@@ -407,7 +422,6 @@ class RelatorioMateriasTramitacaoView(FilterView):
                 qtdes[tipo] = qtde
         context['qtdes'] = qtdes
 
-        qr = self.request.GET.copy()
         context['filter_url'] = ('&' + qr.urlencode()) if len(qr) > 0 else ''
 
         context['show_results'] = show_results_filter_set(qr)


### PR DESCRIPTION
Ao escolher filtrar por unidade ou status de tramitação, o relatório apresenta todas as matérias que estão, mas também as que já tramitaram na unidade / estiveram com aquele status, não trazendo a opção de filtro apenas como situação atual. 
A presente correção filtra por última unidade / status de tramitação, e também altera o campo de filtro de unidade de tramitação, que filtrava pelo campo de origem (unidade_tramitacao_local) e passa a verificar o destino (unidade_tramitacao_destino).