### PR TITLE
Fix #2286

### DIFF
--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -245,7 +245,7 @@ class MateriaLegislativaForm(ModelForm):
             primeiro_autor = True
         else:
             primeiro_autor = False
-            
+
         materia = super(MateriaLegislativaForm, self).save(commit)
         materia.save()
 
@@ -285,15 +285,12 @@ class UnidadeTramitacaoForm(ModelForm):
         unidade = super(UnidadeTramitacaoForm, self).save(commit)
         cd = self.cleaned_data
 
-        if 'orgao' not in cd.keys():
+        if not cd.get('orgao'):
             unidade.orgao = None
-            unidade.orgao_id = None
-        if 'parlamentar' not in cd.keys():
+        if not cd.get('parlamentar'):
             unidade.parlamentar = None
-            unidade.parlamentar_id = None
-        if 'comissao' not in cd.keys():
+        if not cd.get('comissao'):
             unidade.comissao = None
-            unidade.comissao_id = None
 
         unidade.save()
         return unidade

--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -281,6 +281,23 @@ class UnidadeTramitacaoForm(ModelForm):
             raise ValidationError(msg)
         return cleaned_data
 
+    def save(self, commit=False):
+        unidade = super(UnidadeTramitacaoForm, self).save(commit)
+        cd = self.cleaned_data
+
+        if 'orgao' not in cd.keys():
+            unidade.orgao = None
+            unidade.orgao_id = None
+        if 'parlamentar' not in cd.keys():
+            unidade.parlamentar = None
+            unidade.parlamentar_id = None
+        if 'comissao' not in cd.keys():
+            unidade.comissao = None
+            unidade.comissao_id = None
+
+        unidade.save()
+        return unidade
+
 
 class AcompanhamentoMateriaForm(ModelForm):
 


### PR DESCRIPTION
## Descrição
As unidade que não forem selecionadas são setadas para None

## _Issue_ Relacionada
#2286 

## Motivação e Contexto
Algumas unidades de tramitação possuem dois campos preenchidos, o que é incorreto, ao tentar editar para apagar um desses campos a exclusão não é feita, sendo necessário apagar o campo direto do terminal.

## Como Isso Foi Testado?
Testado localmente

## Tipos de Mudanças
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.