### PR TITLE
Fixes #2133

### DIFF
--- a/sapl/base/templatetags/common_tags.py
+++ b/sapl/base/templatetags/common_tags.py
@@ -198,6 +198,19 @@ def url(value):
         return True
     return False
 
+@register.filter
+def audio_url(value):
+    return True if url(value) and value.endswith("mp3") else False
+
+
+@register.filter
+def video_url(value):
+    return True if url(value) and value.endswith("mp4") else False
+
+@register.filter
+def file_extension(value):
+    import pathlib
+    return pathlib.Path(value).suffix.replace('.', '')
 
 @register.filter
 def cronometro_to_seconds(value):

--- a/sapl/templates/base.html
+++ b/sapl/templates/base.html
@@ -1,6 +1,6 @@
+<!DOCTYPE html>
 {% load i18n staticfiles sass_tags menus %}
 {% load common_tags %}
-<!DOCTYPE html>
 <!--[if IE 8]> <html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js" lang="pt-br">

--- a/sapl/templates/crud/detail.html
+++ b/sapl/templates/crud/detail.html
@@ -65,7 +65,21 @@
                   <div id="div_id_{{ column.id }}" class="form-group">
                     <p class="control-label">{{ column.verbose_name }}</p>
                     <div class="controls">
-                      {% if column.text|url %}
+                      {% if column.text|audio_url %}
+                        <div class="form-control-static">
+                            <audio controls>
+                                <source src="{{ column.text|safe }}" type="audio/{{ column.text|file_extension }}">
+                                <p>Este navegador não suporta o elemento áudio.</p>
+                            </audio>
+                        </div>
+                      {% elif column.text|video_url %}
+                        <div class="form-control-static">
+                            <video width="320" height="120" controls>
+                                <source src="{{ column.text|safe }}" type="video/{{ column.text|file_extension }}">
+                                <p>Este navegador não suporta o elemento vídeo.</p>
+                            </video>
+                        </div>
+                      {% elif column.text|url %}
                         <div class="form-control-static"><a href="{{ column.text|safe }}"> {{ column.text|safe|default:"" }} </a></div>
                       {% else %}
                         <div class="form-control-static">{{ column.text|safe|default:"" }}</div>


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
Adiciona players de áudio e vídeo na página de sessão plenária.

## _Issue_ Relacionada
Não se aplica

## Motivação e Contexto
A página mostrava somente links para as mídias. Em alguns browsers isso implicava em links de downloads enquanto outros browsers mais modernos isso levava a páginas dedicadas exclusivamente à reprodução do áudio/vídeo

## Como Isso Foi Testado?
Manualmente

## Capturas de Tela (se apropriado):
![image](https://user-images.githubusercontent.com/9326037/46965152-698c6500-d080-11e8-9db9-b552717809d5.png)


## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [ ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [x] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [ ] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.