### PR TITLE
Fix #2321 - Visualizar autor da materia no detalhe da proposição

### DIFF
--- a/sapl/templates/materia/proposicao_detail.html
+++ b/sapl/templates/materia/proposicao_detail.html
@@ -129,14 +129,30 @@
           <h2 class="legend">{% trans "Vínculo com a Matéria Legislativa" %}</h2>
           <div id="div_id_materia_de_vinculo" class="form-group">
             <div class="controls">
+              Matéria</br>
+              &nbsp;&nbsp;&nbsp;&nbsp;
                 <a href="{% url object.materia_de_vinculo|urldetail object.materia_de_vinculo.id%}">
                   {{object.materia_de_vinculo}}
                 </a>
-            </div>
+              </br>
+                {% if object.materia_de_vinculo.autoria_set.all %}
+            		Autores
+            		{% for a in object.materia_de_vinculo.autoria_set.all %}
+              </br>&nbsp;&nbsp;&nbsp;&nbsp;{{a.autor}}
+                {% endfor %}
+                {% endif %}
+              </br>
+                Texto Original
+              </br>
+              &nbsp;&nbsp;&nbsp;&nbsp;
+                  <a href="{{object.materia_de_vinculo.texto_original.url}}">
+                    {{object.materia_de_vinculo.texto_original| to_str | split:"/" | get_last_item_from_list:-1}}
+                  </a>
+                </br>
           </div>
         </div>
     {% endif %}
-    
+
     {% if not AppConfig.receber_recibo_proposicao %}
         {% if object.hash_code %}
 

--- a/sapl/templates/materia/proposicao_detail.html
+++ b/sapl/templates/materia/proposicao_detail.html
@@ -151,6 +151,7 @@
                 </br>
           </div>
         </div>
+      </div>
     {% endif %}
 
     {% if not AppConfig.receber_recibo_proposicao %}


### PR DESCRIPTION
## Descrição
Visualizar autor e link do arquivo da matéria no detalhe da proposição

## _Issue_ Relacionada
#2321 

## Motivação e Contexto
Facilitar o usuário a visualizar o autor da materia e o anexo sem precisar entrar no detalhe da mesma.

## Como Isso Foi Testado?
Localmente

## Capturas de Tela (se apropriado):
[tela proposição](https://user-images.githubusercontent.com/21279391/47527005-dae5c800-d877-11e8-966f-af1e2d32388f.png)


## Tipos de Mudanças
- [ ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [x] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.