### PR TITLE
HOT-FIX: exclui da lista de cargos únicos cargo próprio

### DIFF
--- a/sapl/comissoes/forms.py
+++ b/sapl/comissoes/forms.py
@@ -243,7 +243,8 @@ class ParticipacaoEditForm(forms.ModelForm):
         composicao_id = self.instance.composicao_id
 
         composicao = Composicao.objects.get(id=composicao_id)
-        cargos_unicos = [c.cargo.nome for c in composicao.participacao_set.filter(cargo__unico=True)]
+        cargos_unicos = [c.cargo.nome for c in
+                         composicao.participacao_set.filter(cargo__unico=True).exclude(id=self.instance.pk)]
 
         if cleaned_data['cargo'].nome in cargos_unicos:
             msg = _('Este cargo é único para esta Comissão.')


### PR DESCRIPTION
## Descrição
<!--- Decreva suas alterações detalhadamente -->
Ao editar uma participação em comissão caso o parlamentar possuísse um cargo único, era apresntado um erro no formulário relatando que aquele cargo só poderia ser preenchido uma única vez. Esse PR muda esse comportamento para que caso o parlamentar já tivesse aquele cargo antes da edição, esse erro não ocorrerá.

## Como Isso Foi Testado?
<!--- Por favor, descreva detalhadamente como você testou suas mudanças. -->
<!--- Inclua detalhes do seu ambiente de teste e os testes que você executou -->
<!--- para ver como a sua alteração afeta outras áreas do código, etc. -->
Na minha máquina local.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.