### PR TITLE
Fix #2342

### DIFF
--- a/sapl/base/email_utils.py
+++ b/sapl/base/email_utils.py
@@ -1,7 +1,6 @@
 from datetime import datetime as dt
 import logging
 
-from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, get_connection, send_mail
 from django.core.urlresolvers import reverse
 from django.template import Context, loader
@@ -11,6 +10,7 @@ from sapl.base.models import CasaLegislativa
 from sapl.materia.models import AcompanhamentoMateria
 from sapl.protocoloadm.models import AcompanhamentoDocumento
 from sapl.settings import EMAIL_SEND_USER
+from sapl.utils import mail_service_configured
 
 
 def load_email_templates(templates, context={}):
@@ -114,7 +114,7 @@ def do_envia_email_confirmacao(base_url, casa, tipo, doc_mat, destinatario):
     # Envia email de confirmacao para atualizações de tramitação
     #
 
-    if not settings.EMAIL_HOST:
+    if not mail_service_configured():
         logger = logging.getLogger(__name__)
         logger.warning(_('Servidor de email não configurado.'))
         return
@@ -208,7 +208,7 @@ def do_envia_email_tramitacao(base_url, tipo, doc_mat, status, unidade_destino):
     # Envia email de tramitacao para usuarios cadastrados
     #
 
-    if not settings.EMAIL_HOST:
+    if not mail_service_configured():
         logger = logging.getLogger(__name__)
         logger.warning(_('Servidor de email não configurado.'))
         return

--- a/sapl/base/email_utils.py
+++ b/sapl/base/email_utils.py
@@ -1,15 +1,16 @@
 from datetime import datetime as dt
+import logging
 
+from django.conf import settings
 from django.core.mail import EmailMultiAlternatives, get_connection, send_mail
 from django.core.urlresolvers import reverse
 from django.template import Context, loader
 from django.utils import timezone
 
 from sapl.base.models import CasaLegislativa
-from sapl.settings import EMAIL_SEND_USER
-
 from sapl.materia.models import AcompanhamentoMateria
 from sapl.protocoloadm.models import AcompanhamentoDocumento
+from sapl.settings import EMAIL_SEND_USER
 
 
 def load_email_templates(templates, context={}):
@@ -94,8 +95,6 @@ def criar_email_confirmacao(base_url, casa_legislativa, doc_mat, tipo, hash_txt=
         ementa = doc_mat.assunto
         autores = ""
 
-
-
     templates = load_email_templates(['email/acompanhar.txt',
                                       'email/acompanhar.html'],
                                      {"casa_legislativa": casa_nome,
@@ -114,6 +113,11 @@ def do_envia_email_confirmacao(base_url, casa, tipo, doc_mat, destinatario):
     #
     # Envia email de confirmacao para atualizações de tramitação
     #
+
+    if not settings.EMAIL_HOST:
+        logger = logging.getLogger(__name__)
+        logger.warning(_('Servidor de email não configurado.'))
+        return
 
     sender = EMAIL_SEND_USER
     # FIXME i18n
@@ -203,12 +207,18 @@ def do_envia_email_tramitacao(base_url, tipo, doc_mat, status, unidade_destino):
     #
     # Envia email de tramitacao para usuarios cadastrados
     #
+
+    if not settings.EMAIL_HOST:
+        logger = logging.getLogger(__name__)
+        logger.warning(_('Servidor de email não configurado.'))
+        return
+
     if tipo == "materia":
         destinatarios = AcompanhamentoMateria.objects.filter(materia=doc_mat,
                                                              confirmado=True)
     else:
         destinatarios = AcompanhamentoDocumento.objects.filter(documento=doc_mat,
-                                                            confirmado=True)
+                                                               confirmado=True)
 
     casa = CasaLegislativa.objects.first()
 

--- a/sapl/base/templatetags/common_tags.py
+++ b/sapl/base/templatetags/common_tags.py
@@ -1,5 +1,8 @@
+import logging
+
 from compressor.utils import get_class
 from django import template
+from django.conf import settings
 from django.template.defaultfilters import stringfilter
 
 from sapl.base.models import AppConfig
@@ -8,12 +11,13 @@ from sapl.norma.models import NormaJuridica
 from sapl.parlamentares.models import Filiacao
 from sapl.utils import filiacao_data, SEPARADOR_HASH_PROPOSICAO
 
+
 register = template.Library()
 
 
 @register.simple_tag
 def define(arg):
-  return arg
+    return arg
 
 
 @register.simple_tag
@@ -48,8 +52,9 @@ def split(value, arg):
 def to_str(arg):
     return str(arg)
 
+
 @register.filter
-def get_last_item_from_list(list,arg):
+def get_last_item_from_list(list, arg):
     return list[arg]
 
 
@@ -59,14 +64,14 @@ def sort_by_keys(value, key):
     id_props = [x.id for x in value]
     qs = Proposicao.objects.filter(pk__in=id_props)
     key_descricao = {'1': 'data_envio',
-                        '-1': '-data_envio',
-                        '2': 'tipo',
-                        '-2': '-tipo',
-                        '3': 'descricao',
-                        '-3': '-descricao',
-                        '4': 'autor',
-                        '-4': '-autor'
-                        }
+                     '-1': '-data_envio',
+                     '2': 'tipo',
+                     '-2': '-tipo',
+                     '3': 'descricao',
+                     '-3': '-descricao',
+                     '4': 'autor',
+                     '-4': '-autor'
+                     }
 
     transformed = qs.order_by(key_descricao[key])
     return transformed
@@ -74,7 +79,7 @@ def sort_by_keys(value, key):
 
 @register.filter
 def paginacao_limite_inferior(pagina):
-    return (int(pagina) - 1) * 10 
+    return (int(pagina) - 1) * 10
 
 
 @register.filter
@@ -101,7 +106,6 @@ def strip_hash(value):
         return vet[0][1:]
     else:
         return value.split(SEPARADOR_HASH_PROPOSICAO)[0][1:]
-
 
 
 @register.filter
@@ -203,6 +207,7 @@ def url(value):
         return True
     return False
 
+
 @register.filter
 def audio_url(value):
     return True if url(value) and value.endswith("mp3") else False
@@ -212,10 +217,12 @@ def audio_url(value):
 def video_url(value):
     return True if url(value) and value.endswith("mp4") else False
 
+
 @register.filter
 def file_extension(value):
     import pathlib
     return pathlib.Path(value).suffix.replace('.', '')
+
 
 @register.filter
 def cronometro_to_seconds(value):

--- a/sapl/base/views.py
+++ b/sapl/base/views.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -170,9 +170,16 @@ class AutorCrud(CrudAux):
             pk_autor = self.object.id
             url_reverse = reverse('sapl.base:autor_detail',
                                   kwargs={'pk': pk_autor})
-            
+
+            if not settings.EMAIL_HOST:
+                self.logger.warning(_('Registro de Autor sem envio de email. '
+                                      'Servidor de email não configurado.'))
+                return url_reverse
+
             try:
-                self.logger.debug('user=' + username + '. Enviando email na edição de Autores.')
+
+                self.logger.debug('user=' + username +
+                                  '. Enviando email na edição de Autores.')
                 kwargs = {}
                 user = self.object.user
 
@@ -200,8 +207,9 @@ class AutorCrud(CrudAux):
                 send_mail(assunto, mensagem, remetente, destinatario,
                           fail_silently=False)
             except Exception as e:
-                self.logger.error('user=' + username + '. Erro no envio de email na edição de Autores. ' + str(e))
-                
+                self.logger.error(
+                    'user=' + username + '. Erro no envio de email na edição de Autores. ' + str(e))
+
             return url_reverse
 
     class CreateView(CrudAux.CreateView):
@@ -224,9 +232,15 @@ class AutorCrud(CrudAux):
             pk_autor = self.object.id
             url_reverse = reverse('sapl.base:autor_detail',
                                   kwargs={'pk': pk_autor})
-            
+
+            if not settings.EMAIL_HOST:
+                self.logger.warning(_('Registro de Autor sem envio de email. '
+                                      'Servidor de email não configurado.'))
+                return url_reverse
+
             try:
-                self.logger.debug('user=' + username + '. Enviando email na criação de Autores.')
+                self.logger.debug('user=' + username +
+                                  '. Enviando email na criação de Autores.')
 
                 kwargs = {}
                 user = self.object.user
@@ -257,8 +271,9 @@ class AutorCrud(CrudAux):
             except Exception as e:
                 print(
                     _('Erro no envio de email na criação de Autores.'))
-                self.logger.error('user=' + username + '. Erro no envio de email na criação de Autores. ' + str(e))
-                    
+                self.logger.error(
+                    'user=' + username + '. Erro no envio de email na criação de Autores. ' + str(e))
+
             return url_reverse
 
 
@@ -347,18 +362,21 @@ class RelatorioPresencaSessaoView(FilterView):
                 'ordemdia_porc': 0
             })
             try:
-                self.logger.debug('user=' + username + '. Tentando obter presença do parlamentar (pk={}).'.format(p.id))
+                self.logger.debug(
+                    'user=' + username + '. Tentando obter presença do parlamentar (pk={}).'.format(p.id))
                 sessao_count = presenca_sessao.get(parlamentar_id=p.id)[1]
             except ObjectDoesNotExist as e:
-                self.logger.error('user=' + username + '. Erro ao obter presença do parlamentar (pk={}). Definido como 0. '.format(p.id) + str(e))
+                self.logger.error(
+                    'user=' + username + '. Erro ao obter presença do parlamentar (pk={}). Definido como 0. '.format(p.id) + str(e))
                 sessao_count = 0
             try:
                 # Presenças de cada Ordem do Dia
-                self.logger.info('user=' + username + '. Tentando obter PresencaOrdemDia para o parlamentar pk={}.'.format(p.id))
+                self.logger.info(
+                    'user=' + username + '. Tentando obter PresencaOrdemDia para o parlamentar pk={}.'.format(p.id))
                 ordemdia_count = presenca_ordem.get(parlamentar_id=p.id)[1]
             except ObjectDoesNotExist:
                 self.logger.error('user=' + username + '. Erro ao obter PresencaOrdemDia para o parlamentar pk={}. '
-                                    'Definido como 0.'.format(p.id))
+                                  'Definido como 0.'.format(p.id))
                 ordemdia_count = 0
 
             parlamentares_presencas[i].update({
@@ -871,14 +889,16 @@ class HelpTopicView(TemplateView):
     logger = logging.getLogger(__name__)
 
     def get_template_names(self):
-        
+
         username = self.request.user.username
         topico = self.kwargs['topic']
         try:
-            self.logger.debug('user=' + username + '. Tentando obter template %s.html.' % topico)
+            self.logger.debug('user=' + username +
+                              '. Tentando obter template %s.html.' % topico)
             get_template('ajuda/%s.html' % topico)
         except TemplateDoesNotExist as e:
-            self.logger.error('user=' + username + '. Erro ao obter template {}.html. Template não existe. '.format(topico) + str(e))
+            self.logger.error(
+                'user=' + username + '. Erro ao obter template {}.html. Template não existe. '.format(topico) + str(e))
             raise Http404()
         return ['ajuda/%s.html' % topico]
 

--- a/sapl/base/views.py
+++ b/sapl/base/views.py
@@ -201,7 +201,7 @@ class AutorCrud(CrudAux):
                     "ignore esta mensagem. Caso tenha, clique " +
                     "no link abaixo\n" + url_base +
                     reverse('sapl.base:confirmar_email', kwargs=kwargs))
-                remetente = [settings.EMAIL_SEND_USER]
+                remetente = settings.EMAIL_SEND_USER
                 destinatario = [user.email]
                 send_mail(assunto, mensagem, remetente, destinatario,
                           fail_silently=False)
@@ -263,7 +263,7 @@ class AutorCrud(CrudAux):
                     "ignore esta mensagem. Caso tenha, clique " +
                     "no link abaixo\n" + url_base +
                     reverse('sapl.base:confirmar_email', kwargs=kwargs))
-                remetente = [settings.EMAIL_SEND_USER]
+                remetente = settings.EMAIL_SEND_USER
                 destinatario = [user.email]
                 send_mail(assunto, mensagem, remetente, destinatario,
                           fail_silently=False)

--- a/sapl/base/views.py
+++ b/sapl/base/views.py
@@ -33,7 +33,7 @@ from sapl.materia.models import (Autoria, MateriaLegislativa,
 from sapl.sessao.models import (PresencaOrdemDia, SessaoPlenaria,
                                 SessaoPlenariaPresenca)
 from sapl.utils import (parlamentares_ativos,
-                        show_results_filter_set)
+                        show_results_filter_set, mail_service_configured)
 
 from .forms import (AlterarSenhaForm, CasaLegislativaForm,
                     ConfiguracoesAppForm, RelatorioAtasFilterSet,
@@ -171,15 +171,14 @@ class AutorCrud(CrudAux):
             url_reverse = reverse('sapl.base:autor_detail',
                                   kwargs={'pk': pk_autor})
 
-            if not settings.EMAIL_HOST:
+            if not mail_service_configured():
                 self.logger.warning(_('Registro de Autor sem envio de email. '
                                       'Servidor de email não configurado.'))
                 return url_reverse
 
             try:
-
-                self.logger.debug('user=' + username +
-                                  '. Enviando email na edição de Autores.')
+                self.logger.debug('user={}. Enviando email na edição '
+                                  'de Autores.'.format(username))
                 kwargs = {}
                 user = self.object.user
 
@@ -207,8 +206,8 @@ class AutorCrud(CrudAux):
                 send_mail(assunto, mensagem, remetente, destinatario,
                           fail_silently=False)
             except Exception as e:
-                self.logger.error(
-                    'user=' + username + '. Erro no envio de email na edição de Autores. ' + str(e))
+                self.logger.error('user={}. Erro no envio de email na edição de'
+                                  ' Autores. {}'.format(username, str(e)))
 
             return url_reverse
 
@@ -233,7 +232,7 @@ class AutorCrud(CrudAux):
             url_reverse = reverse('sapl.base:autor_detail',
                                   kwargs={'pk': pk_autor})
 
-            if not settings.EMAIL_HOST:
+            if not mail_service_configured():
                 self.logger.warning(_('Registro de Autor sem envio de email. '
                                       'Servidor de email não configurado.'))
                 return url_reverse

--- a/sapl/context_processors.py
+++ b/sapl/context_processors.py
@@ -1,3 +1,8 @@
+import logging
+
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
 from sapl.base.views import get_casalegislativa
 
 
@@ -7,3 +12,12 @@ def parliament_info(request):
         return casa.__dict__
     else:
         return {}
+
+
+def mail_service_configured(request):
+
+    if not settings.EMAIL_HOST:
+        logger = logging.getLogger(__name__)
+        logger.warning(_('Servidor de email não configurado.'))
+        return {'mail_service_configured': False}
+    return {'mail_service_configured': True}

--- a/sapl/context_processors.py
+++ b/sapl/context_processors.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from sapl.base.views import get_casalegislativa
+from sapl.utils import mail_service_configured as mail_service_configured_utils
 
 
 def parliament_info(request):
@@ -16,7 +17,7 @@ def parliament_info(request):
 
 def mail_service_configured(request):
 
-    if not settings.EMAIL_HOST:
+    if not mail_service_configured_utils():
         logger = logging.getLogger(__name__)
         logger.warning(_('Servidor de email não configurado.'))
         return {'mail_service_configured': False}

--- a/sapl/context_processors.py
+++ b/sapl/context_processors.py
@@ -17,7 +17,7 @@ def parliament_info(request):
 
 def mail_service_configured(request):
 
-    if not mail_service_configured_utils():
+    if not mail_service_configured_utils(request):
         logger = logging.getLogger(__name__)
         logger.warning(_('Servidor de email não configurado.'))
         return {'mail_service_configured': False}

--- a/sapl/materia/views.py
+++ b/sapl/materia/views.py
@@ -48,7 +48,7 @@ from sapl.protocoloadm.models import Protocolo
 from sapl.utils import (YES_NO_CHOICES, autor_label, autor_modal, SEPARADOR_HASH_PROPOSICAO,
                         gerar_hash_arquivo, get_base_url,
                         get_mime_type_from_file_extension, montar_row_autor,
-                        show_results_filter_set)
+                        show_results_filter_set, mail_service_configured)
 
 from .forms import (AcessorioEmLoteFilterSet, AcompanhamentoMateriaForm,
                     AdicionarVariasAutoriasFilterSet, DespachoInicialForm,
@@ -1822,7 +1822,7 @@ class AcompanhamentoMateriaView(CreateView):
         return ''.join(choice(s) for i in range(choice([6, 7])))
 
     def get(self, request, *args, **kwargs):
-        if not settings.EMAIL_HOST:
+        if not mail_service_configured():
             self.logger.warning(_('Servidor de email não configurado.'))
             messages.error(request, _('Serviço de Acompanhamento de '
                                       'Matérias não foi configurado'))

--- a/sapl/protocoloadm/views.py
+++ b/sapl/protocoloadm/views.py
@@ -33,7 +33,7 @@ from sapl.parlamentares.models import Legislatura, Parlamentar
 from sapl.protocoloadm.models import Protocolo
 from sapl.utils import (create_barcode, get_base_url, get_client_ip,
                         get_mime_type_from_file_extension,
-                        show_results_filter_set)
+                        show_results_filter_set, mail_service_configured)
 
 from .forms import (AcompanhamentoDocumentoForm, AnularProcoloAdmForm,
                     DocumentoAcessorioAdministrativoForm,
@@ -186,7 +186,7 @@ class AcompanhamentoDocumentoView(CreateView):
         return ''.join(choice(s) for i in range(choice([6, 7])))
 
     def get(self, request, *args, **kwargs):
-        if not settings.EMAIL_HOST:
+        if not mail_service_configured():
             self.logger.warning(_('Servidor de email não configurado.'))
             messages.error(request, _('Serviço de Acompanhamento de '
                                       'Documentos não foi configurado'))
@@ -200,7 +200,7 @@ class AcompanhamentoDocumentoView(CreateView):
              'documento': documento})
 
     def post(self, request, *args, **kwargs):
-        if not settings.EMAIL_HOST:
+        if not mail_service_configured():
             self.logger.warning(_('Servidor de email não configurado.'))
             messages.error(request, _('Serviço de Acompanhamento de '
                                       'Documentos não foi configurado'))

--- a/sapl/protocoloadm/views.py
+++ b/sapl/protocoloadm/views.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+import logging
 from random import choice
 from string import ascii_letters, digits
 
 from braces.views import FormValidMessageMixin
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -21,9 +23,10 @@ from django.views.generic.edit import FormView
 from django_filters.views import FilterView
 
 import sapl
-import logging
-from sapl.comissoes.models import Comissao
+from sapl.base.email_utils import do_envia_email_confirmacao
 from sapl.base.models import Autor, CasaLegislativa
+from sapl.base.signals import tramitacao_signal
+from sapl.comissoes.models import Comissao
 from sapl.crud.base import Crud, CrudAux, MasterDetailCrud, make_pagination
 from sapl.materia.models import MateriaLegislativa, TipoMateriaLegislativa
 from sapl.parlamentares.models import Legislatura, Parlamentar
@@ -31,7 +34,7 @@ from sapl.protocoloadm.models import Protocolo
 from sapl.utils import (create_barcode, get_base_url, get_client_ip,
                         get_mime_type_from_file_extension,
                         show_results_filter_set)
-from sapl.base.email_utils import do_envia_email_confirmacao
+
 from .forms import (AcompanhamentoDocumentoForm, AnularProcoloAdmForm,
                     DocumentoAcessorioAdministrativoForm,
                     DocumentoAdministrativoFilterSet,
@@ -44,7 +47,6 @@ from .forms import (AcompanhamentoDocumentoForm, AnularProcoloAdmForm,
 from .models import (AcompanhamentoDocumento, DocumentoAcessorioAdministrativo,
                      DocumentoAdministrativo, StatusTramitacaoAdministrativo,
                      TipoDocumentoAdministrativo, TramitacaoAdministrativo)
-from sapl.base.signals import tramitacao_signal
 
 
 TipoDocumentoAdministrativoCrud = CrudAux.build(
@@ -63,20 +65,22 @@ def recuperar_materia_protocolo(request):
     logger = logging.getLogger(__name__)
     username = request.user.username
     try:
-        logger.debug("user=" + username + ". Tentando obter matéria com tipo={}, ano={} e numero={}.".format(tipo, ano, numero))
+        logger.debug("user=" + username +
+                     ". Tentando obter matéria com tipo={}, ano={} e numero={}.".format(tipo, ano, numero))
         materia = MateriaLegislativa.objects.get(
-            tipo=tipo, ano=ano,numero=numero)
+            tipo=tipo, ano=ano, numero=numero)
         autoria = materia.autoria_set.first()
         content = {'ementa': materia.ementa.strip(),
-                    'ano':materia.ano, 'numero':materia.numero}
+                   'ano': materia.ano, 'numero': materia.numero}
         if autoria:
             content.update({'autor': autoria.autor.pk,
-                            'tipo_autor':autoria.autor.tipo.pk})
+                            'tipo_autor': autoria.autor.tipo.pk})
         response = JsonResponse(content)
     except Exception as e:
         logger.error("user=" + username + ". " + str(e))
-        response = JsonResponse({'error':e})
+        response = JsonResponse({'error': e})
     return response
+
 
 def doc_texto_integral(request, pk):
     can_see = True
@@ -102,13 +106,15 @@ def doc_texto_integral(request, pk):
             return response
     raise Http404
 
+
 class AcompanhamentoConfirmarView(TemplateView):
 
     logger = logging.getLogger(__name__)
 
     def get_redirect_url(self, email):
         username = self.request.user.username
-        self.logger.info('user=' + username + '. Este documento está sendo acompanhado pelo e-mail: {}'.format(email))
+        self.logger.info(
+            'user=' + username + '. Este documento está sendo acompanhado pelo e-mail: {}'.format(email))
         msg = _('Este documento está sendo acompanhado pelo e-mail: %s') % (
             email)
         messages.add_message(self.request, messages.SUCCESS, msg)
@@ -116,6 +122,7 @@ class AcompanhamentoConfirmarView(TemplateView):
                        kwargs={'pk': self.kwargs['pk']})
 
     def get(self, request, *args, **kwargs):
+
         documento_id = kwargs['pk']
         hash_txt = request.GET.get('hash_txt', '')
         username = request.user.username
@@ -146,7 +153,8 @@ class AcompanhamentoExcluirView(TemplateView):
 
     def get_success_url(self):
         username = self.request.user.username
-        self.logger.info("user=" + username + ". Você parou de acompanhar este Documento (pk={}).".format(self.kwargs['pk']))
+        self.logger.info(
+            "user=" + username + ". Você parou de acompanhar este Documento (pk={}).".format(self.kwargs['pk']))
         msg = _('Você parou de acompanhar este Documento.')
         messages.add_message(self.request, messages.INFO, msg)
         return reverse('sapl.protocoloadm:documentoadministrativo_detail',
@@ -160,7 +168,7 @@ class AcompanhamentoExcluirView(TemplateView):
             self.logger.debug("user=" + username + ". Tentando obter AcompanhamentoDocumento com documento_id={} e hash={}."
                               .format(documento_id, hash_txt))
             AcompanhamentoDocumento.objects.get(documento_id=documento_id,
-                                              hash=hash_txt).delete()
+                                                hash=hash_txt).delete()
         except ObjectDoesNotExist:
             self.logger.error("user=" + username + ". AcompanhamentoDocumento com documento_id={} e hash={} não encontrado."
                               .format(documento_id, hash_txt))
@@ -178,6 +186,12 @@ class AcompanhamentoDocumentoView(CreateView):
         return ''.join(choice(s) for i in range(choice([6, 7])))
 
     def get(self, request, *args, **kwargs):
+        if not settings.EMAIL_HOST:
+            self.logger.warning(_('Servidor de email não configurado.'))
+            messages.error(request, _('Serviço de Acompanhamento de '
+                                      'Documentos não foi configurado'))
+            return redirect('/')
+
         pk = self.kwargs['pk']
         documento = DocumentoAdministrativo.objects.get(id=pk)
 
@@ -186,6 +200,12 @@ class AcompanhamentoDocumentoView(CreateView):
              'documento': documento})
 
     def post(self, request, *args, **kwargs):
+        if not settings.EMAIL_HOST:
+            self.logger.warning(_('Servidor de email não configurado.'))
+            messages.error(request, _('Serviço de Acompanhamento de '
+                                      'Documentos não foi configurado'))
+            return redirect('/')
+
         form = AcompanhamentoDocumentoForm(request.POST)
         pk = self.kwargs['pk']
         documento = DocumentoAdministrativo.objects.get(id=pk)
@@ -233,7 +253,8 @@ class AcompanhamentoDocumentoView(CreateView):
             # Caso esse Acompanhamento já exista
             # avisa ao usuário que esse documento já está sendo acompanhado
             else:
-                self.logger.info('user=' + request.user.username + '. Este e-mail já está acompanhando esse documento (pk={}).'.format(pk))
+                self.logger.info('user=' + request.user.username +
+                                 '. Este e-mail já está acompanhando esse documento (pk={}).'.format(pk))
                 msg = _('Este e-mail já está acompanhando esse documento.')
                 messages.add_message(request, messages.INFO, msg)
 
@@ -474,7 +495,8 @@ class ProtocoloDocumentoView(PermissionRequiredMixin,
         protocolo = form.save(commit=False)
         username = self.request.user.username
         try:
-            self.logger.debug("user=" + username + ". Tentando obter sequência de numeração.")
+            self.logger.debug("user=" + username +
+                              ". Tentando obter sequência de numeração.")
             numeracao = sapl.base.models.AppConfig.objects.last(
             ).sequencia_numeracao
         except AttributeError as e:
@@ -504,10 +526,13 @@ class ProtocoloDocumentoView(PermissionRequiredMixin,
         protocolo.tipo_processo = '0'  # TODO validar o significado
         protocolo.anulado = False
         if not protocolo.numero:
-            protocolo.numero = (numero['numero__max'] + 1) if numero['numero__max'] else 1
+            protocolo.numero = (
+                numero['numero__max'] + 1) if numero['numero__max'] else 1
         elif protocolo.numero < (numero['numero__max'] + 1) if numero['numero__max'] else 0:
-            msg = _('Número de protocolo deve ser maior que {}'.format(numero['numero__max']))
-            self.logger.error("user=" + username + ". Número de protocolo deve ser maior que {}.".format(numero['numero__max']))
+            msg = _('Número de protocolo deve ser maior que {}'.format(
+                numero['numero__max']))
+            self.logger.error(
+                "user=" + username + ". Número de protocolo deve ser maior que {}.".format(numero['numero__max']))
             messages.add_message(self.request, messages.ERROR, msg)
             return self.render_to_response(self.get_context_data())
         protocolo.ano = timezone.now().year
@@ -564,7 +589,8 @@ class ProtocoloMostrarView(PermissionRequiredMixin, TemplateView):
 
         if protocolo.tipo_materia:
             self.logger.debug(
-                "user=" + username + ". Tentando obter objeto MateriaLegislativa com numero_protocolo={} e ano={}."
+                "user=" + username +
+                ". Tentando obter objeto MateriaLegislativa com numero_protocolo={} e ano={}."
                 .format(protocolo.numero, protocolo.ano))
             materia = MateriaLegislativa.objects.filter(
                 numero_protocolo=protocolo.numero, ano=protocolo.ano)
@@ -636,7 +662,8 @@ class ProtocoloMateriaView(PermissionRequiredMixin, CreateView):
         protocolo = form.save(commit=False)
         username = self.request.user.username
         try:
-            self.logger.debug("user=" + username + ". Tentando obter sequência de numeração.")
+            self.logger.debug("user=" + username +
+                              ". Tentando obter sequência de numeração.")
             numeracao = sapl.base.models.AppConfig.objects.last(
             ).sequencia_numeracao
         except AttributeError:
@@ -667,12 +694,14 @@ class ProtocoloMateriaView(PermissionRequiredMixin, CreateView):
             numero['numero__max'] = 0
 
         if not protocolo.numero:
-            protocolo.numero = (numero['numero__max'] + 1) if numero['numero__max'] else 1
+            protocolo.numero = (
+                numero['numero__max'] + 1) if numero['numero__max'] else 1
         if numero['numero__max']:
             if protocolo.numero < (numero['numero__max'] + 1):
                 self.logger.error("user=" + username + ". Número de protocolo ({}) é menor que {}"
                                   .format(protocolo.numero, numero['numero__max']))
-                msg = _('Número de protocolo deve ser maior que {}').format(numero['numero__max'])
+                msg = _('Número de protocolo deve ser maior que {}').format(
+                    numero['numero__max'])
                 messages.add_message(self.request, messages.ERROR, msg)
                 return self.render_to_response(self.get_context_data())
         protocolo.ano = timezone.now().year
@@ -766,11 +795,11 @@ class PesquisarDocumentoAdministrativoView(DocumentoAdministrativoMixin,
         qs = self.get_queryset()
 
         qs = qs.prefetch_related("documentoacessorioadministrativo_set",
-                 "tramitacaoadministrativo_set",
-                 "tipo",
-                 "tramitacaoadministrativo_set__status",
-                 "tramitacaoadministrativo_set__unidade_tramitacao_local",
-                 "tramitacaoadministrativo_set__unidade_tramitacao_destino")
+                                 "tramitacaoadministrativo_set",
+                                 "tipo",
+                                 "tramitacaoadministrativo_set__status",
+                                 "tramitacaoadministrativo_set__unidade_tramitacao_local",
+                                 "tramitacaoadministrativo_set__unidade_tramitacao_destino")
 
         if status_tramitacao and unidade_destino:
             lista = filtra_tramitacao_adm_destino_and_status(status_tramitacao,
@@ -787,7 +816,6 @@ class PesquisarDocumentoAdministrativoView(DocumentoAdministrativoMixin,
 
         if 'o' in self.request.GET and not self.request.GET['o']:
             qs = qs.order_by('-ano', '-numero')
-
 
         kwargs.update({
             'queryset': qs,
@@ -823,14 +851,15 @@ class PesquisarDocumentoAdministrativoView(DocumentoAdministrativoMixin,
             url = ''
 
         self.filterset.form.fields['o'].label = _('Ordenação')
-        
-        # é usada essa verificação anônima para quando os documentos administrativos 
-        # estão no modo ostensivo, mas podem existir documentos administrativos restritos
+
+        # é usada essa verificação anônima para quando os documentos administrativos
+        # estão no modo ostensivo, mas podem existir documentos administrativos
+        # restritos
         if request.user.is_anonymous():
             length = self.object_list.filter(restrito=False).count()
         else:
             length = self.object_list.count()
-        
+
         context = self.get_context_data(filter=self.filterset,
                                         filter_url=url,
                                         numero_res=length
@@ -864,7 +893,7 @@ class TramitacaoAdmCrud(MasterDetailCrud):
 
             if local:
                 initial['unidade_tramitacao_local'
-                             ] = local.unidade_tramitacao_destino.pk
+                        ] = local.unidade_tramitacao_destino.pk
             else:
                 initial['unidade_tramitacao_local'] = ''
             initial['data_tramitacao'] = timezone.now().date()
@@ -905,6 +934,7 @@ class TramitacaoAdmCrud(MasterDetailCrud):
     class UpdateView(MasterDetailCrud.UpdateView):
         form_class = TramitacaoAdmEditForm
         logger = logging.getLogger(__name__)
+
         def form_valid(self, form):
             self.object = form.save()
             username = self.request.user.username
@@ -918,8 +948,8 @@ class TramitacaoAdmCrud(MasterDetailCrud):
                                   'não enviado. A não configuração do servidor de e-mail '
                                   'impede o envio de aviso de tramitação. ' + str(e))
                 msg = _('Tramitação criada, mas e-mail de acompanhamento '
-                    'de documento não enviado. A não configuração do'
-                    ' servidor de e-mail impede o envio de aviso de tramitação')
+                        'de documento não enviado. A não configuração do'
+                        ' servidor de e-mail impede o envio de aviso de tramitação')
                 messages.add_message(self.request, messages.WARNING, msg)
                 return HttpResponseRedirect(self.get_success_url())
             return super().form_valid(form)
@@ -1038,8 +1068,8 @@ class DesvincularMateriaView(PermissionRequiredMixin, FormView):
 
     def form_valid(self, form):
         materia = MateriaLegislativa.objects.get(numero=form.cleaned_data['numero'],
-                                                        ano=form.cleaned_data['ano'],
-                                                        tipo=form.cleaned_data['tipo'])
+                                                 ano=form.cleaned_data['ano'],
+                                                 tipo=form.cleaned_data['tipo'])
         materia.numero_protocolo = None
         materia.save()
         return redirect(self.get_success_url())

--- a/sapl/settings.py
+++ b/sapl/settings.py
@@ -225,6 +225,7 @@ EMAIL_USE_TLS = config('EMAIL_USE_TLS', cast=bool, default=True)
 EMAIL_SEND_USER = config('EMAIL_SEND_USER', cast=str, default='')
 DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', cast=str, default='')
 SERVER_EMAIL = config('SERVER_EMAIL', cast=str, default='')
+EMAIL_RUNNING = None
 
 MAX_DOC_UPLOAD_SIZE = 60 * 1024 * 1024  # 60MB
 MAX_IMAGE_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MB

--- a/sapl/settings.py
+++ b/sapl/settings.py
@@ -13,8 +13,8 @@ Quick-start development settings - unsuitable for production
 See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
 
 """
-import socket
 import logging
+import socket
 
 from decouple import config
 from dj_database_url import parse as db_url
@@ -23,6 +23,7 @@ from unipath import Path
 
 from .temp_suppress_crispy_form_warnings import \
     SUPRESS_CRISPY_FORM_WARNINGS_LOGGING
+
 
 host = socket.gethostbyname_ex(socket.gethostname())[0]
 
@@ -181,6 +182,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 'django.contrib.messages.context_processors.messages',
                 'sapl.context_processors.parliament_info',
+                'sapl.context_processors.mail_service_configured',
             ],
             'debug': DEBUG
         },
@@ -314,10 +316,10 @@ LOGGING = {
             'formatter': 'simple',
         },
         'applogfile': {
-            'level':'INFO',
-            'class':'logging.handlers.RotatingFileHandler',
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
             'filename': 'sapl.log',
-            'maxBytes': 1024*1024*15, # 15MB
+            'maxBytes': 1024 * 1024 * 15,  # 15MB
             'backupCount': 10,
             'formatter': 'verbose',
         },

--- a/sapl/templates/materia/materialegislativa_detail.html
+++ b/sapl/templates/materia/materialegislativa_detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block sub_actions %}
     {{ block.super }}
-    {% if object.em_tramitacao %}
+    {% if object.em_tramitacao and mail_service_configured %}
        <div class="actions btn-group btn-group-sm" role="group">
        <a href="{% url 'sapl.materia:acompanhar_materia' object.id %}" class="btn btn-default">Acompanhar Matéria</a>
        </div>

--- a/sapl/templates/materia/materialegislativa_filter.html
+++ b/sapl/templates/materia/materialegislativa_filter.html
@@ -145,7 +145,7 @@
                   {% endfor %}
                 {% endif %}
                 <p></p>
-                {% if m.em_tramitacao %}
+                {% if m.em_tramitacao and mail_service_configured %}
                   <a href="{% url 'sapl.materia:acompanhar_materia' m.id %}">Acompanhar Matéria</a>
                 {% endif %}
                 </td>

--- a/sapl/templates/protocoloadm/documentoadministrativo_filter.html
+++ b/sapl/templates/protocoloadm/documentoadministrativo_filter.html
@@ -63,7 +63,7 @@
               {% if d.texto_integral %}
                 <strong><a href="{{ d.texto_integral.url }}">Texto Integral</a></strong></br>
               {% endif %}
-              {% if d.tramitacao %}
+              {% if d.tramitacao and mail_service_configured %}
                 <a href="{% url 'sapl.protocoloadm:acompanhar_documento' d.id %}">Acompanhar Documento</a>
               {% endif %}
             </td>

--- a/sapl/utils.py
+++ b/sapl/utils.py
@@ -15,6 +15,7 @@ from django.contrib import admin
 from django.contrib.contenttypes.fields import (GenericForeignKey, GenericRel,
                                                 GenericRelation)
 from django.core.exceptions import ValidationError
+from django.core.mail import get_connection
 from django.db.models import Q
 from django.utils import six, timezone
 from django.utils.translation import ugettext_lazy as _
@@ -28,10 +29,12 @@ from unipath.path import Path
 
 from sapl.crispy_layout_mixin import SaplFormLayout, form_actions, to_row
 
+
 # (26/10/2018): O separador foi mudador de '/' para 'K'
 # por conta dos leitores de códigos de barra, que trocavam
 # a '/' por '&' ou ';'
 SEPARADOR_HASH_PROPOSICAO = 'K'
+
 
 def pil_image(source, exif_orientation=False, **options):
     return source_generators.pil_image(source, exif_orientation, **options)
@@ -767,3 +770,16 @@ def RemoveTag(texto):
 
 def remover_acentos(string):
     return unicodedata.normalize('NFKD', string).encode('ASCII', 'ignore').decode()
+
+
+def mail_service_configured(request=None):
+    result = True
+    try:
+        connection = get_connection()
+        connection.open()
+    except Exception as e:
+        result = False
+        print(e)
+    finally:
+        connection.close()
+    return result

--- a/sapl/utils.py
+++ b/sapl/utils.py
@@ -773,13 +773,16 @@ def remover_acentos(string):
 
 
 def mail_service_configured(request=None):
-    result = True
-    try:
-        connection = get_connection()
-        connection.open()
-    except Exception as e:
-        result = False
-        print(e)
-    finally:
-        connection.close()
-    return result
+
+    if settings.EMAIL_RUNNING is None:
+        result = True
+        try:
+            connection = get_connection()
+            connection.open()
+        except Exception as e:
+            result = False
+        finally:
+            connection.close()
+        settings.EMAIL_RUNNING = result
+
+    return settings.EMAIL_RUNNING


### PR DESCRIPTION
Insere verificação de serviço de email configurado. Assume que
EMAIL_HOST vazio é serviço desativado não enviando, assim, email na
edição/adição de autor, bem como desativando acesso via get/post e
por link de "Acompanhar Matéria" na lista de resultados da
pesquisa de matéria e na tela de detalhes de matérias.
Comportamento análogo para Documentos Administrativos.