### PR TITLE
Fixes #2390

### DIFF
--- a/sapl/relatorios/views.py
+++ b/sapl/relatorios/views.py
@@ -1083,8 +1083,7 @@ def get_pauta_sessao(sessao, casa):
     inf_basicas_dic["nom_camara"] = casa.nome
 
     lst_expediente_materia = []
-    for expediente_materia in ExpedienteMateria.objects.filter(
-            data_ordem=sessao.data_inicio, sessao_plenaria=sessao):
+    for expediente_materia in ExpedienteMateria.objects.filter(sessao_plenaria=sessao):
 
         materia = MateriaLegislativa.objects.filter(
             id=expediente_materia.materia.id).first()


### PR DESCRIPTION
A listagem de matérias em expediente matéria não leva em conta somente a sessão plenária, mas também pesquisava por datas de ordem iguais.

## Descrição
Vide descrição acima.

## Motivação e Contexto
Um erro em relatório PDF que somente se manifesta se ordens forem inseridas em datas diferentes.

## Como Isso Foi Testado?
Manualmente.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [X] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [ ] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [ ] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.