### PR TITLE
Fix #26

### DIFF
--- a/sapl/audiencia/models.py
+++ b/sapl/audiencia/models.py
@@ -1,11 +1,11 @@
-import reversion
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from model_utils import Choices
+import reversion
+
 from sapl.materia.models import MateriaLegislativa
 from sapl.parlamentares.models import (CargoMesa, Parlamentar)
-
 from sapl.utils import (YES_NO_CHOICES, SaplGenericRelation,
                         restringe_tipos_de_arquivo_txt, texto_upload_path)
 
@@ -39,7 +39,6 @@ class TipoAudienciaPublica(models.Model):
         max_length=50, verbose_name=_('Nome do Tipo de Audiência Pública'), default='Audiência Pública')
     tipo = models.CharField(
         max_length=1, verbose_name=_('Tipo de Audiência Pública'), choices=TIPO_AUDIENCIA_CHOICES, default='A')
-
 
     class Meta:
         verbose_name = _('Tipo de Audiência Pública')
@@ -111,19 +110,6 @@ class AudienciaPublica(models.Model):
     def __str__(self):
         return self.nome
 
-    def delete(self, using=None, keep_parents=False):
-        if self.upload_pauta:
-            self.upload_pauta.delete()
-
-        if self.upload_ata:
-            self.upload_ata.delete()
-
-        if self.upload_anexo:
-            self.upload_anexo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
-
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
 
@@ -159,7 +145,7 @@ class AnexoAudienciaPublica(models.Model):
         null=True,
         upload_to=texto_upload_path,
         verbose_name=_('Arquivo'))
-    data = models.DateField(auto_now=timezone.now,blank=True, null=True)
+    data = models.DateField(auto_now=timezone.now, blank=True, null=True)
     assunto = models.TextField(
         blank=True, verbose_name=_('Assunto'))
 
@@ -169,13 +155,6 @@ class AnexoAudienciaPublica(models.Model):
 
     def __str__(self):
         return self.assunto
-
-    def delete(self, using=None, keep_parents=False):
-        if self.arquivo:
-            self.arquivo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
 
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):

--- a/sapl/comissoes/models.py
+++ b/sapl/comissoes/models.py
@@ -1,7 +1,7 @@
-import reversion
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from model_utils import Choices
+import reversion
 
 from sapl.base.models import Autor
 from sapl.parlamentares.models import Parlamentar
@@ -256,19 +256,6 @@ class Reuniao(models.Model):
     def __str__(self):
         return self.nome
 
-    def delete(self, using=None, keep_parents=False):
-        if self.upload_pauta:
-            self.upload_pauta.delete()
-
-        if self.upload_ata:
-            self.upload_ata.delete()
-
-        if self.upload_anexo:
-            self.upload_anexo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
-
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
 
@@ -328,13 +315,6 @@ class DocumentoAcessorio(models.Model):
         return _('%(nome)s por %(autor)s') % {
             'nome': self.nome,
             'autor': self.autor}
-
-    def delete(self, using=None, keep_parents=False):
-        if self.arquivo:
-            self.arquivo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
 
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):

--- a/sapl/materia/models.py
+++ b/sapl/materia/models.py
@@ -273,9 +273,6 @@ class MateriaLegislativa(models.Model):
             return ''
 
     def delete(self, using=None, keep_parents=False):
-        if self.texto_original:
-            self.texto_original.delete()
-
         for p in self.proposicao.all():
             p.conteudo_gerado_related = None
             p.cancelado = True
@@ -473,8 +470,6 @@ class DocumentoAcessorio(models.Model):
             'autor': self.autor}
 
     def delete(self, using=None, keep_parents=False):
-        if self.arquivo:
-            self.arquivo.delete()
 
         for p in self.proposicao.all():
             p.conteudo_gerado_related = None
@@ -787,13 +782,6 @@ class Proposicao(models.Model):
                 self.data_envio if self.data_envio else timezone.now(),
                 "d \d\e F \d\e Y"
             )}
-
-    def delete(self, using=None, keep_parents=False):
-        if self.texto_original:
-            self.texto_original.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
 
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):

--- a/sapl/norma/models.py
+++ b/sapl/norma/models.py
@@ -119,7 +119,8 @@ class NormaJuridica(models.Model):
     assuntos = models.ManyToManyField(
         AssuntoNorma, blank=True,
         verbose_name=_('Assuntos'))
-    data_vigencia = models.DateField(blank=True, null=True, verbose_name=_('Data Fim Vigência'))
+    data_vigencia = models.DateField(
+        blank=True, null=True, verbose_name=_('Data Fim Vigência'))
     timestamp = models.DateTimeField(null=True)
 
     texto_articulado = GenericRelation(
@@ -166,13 +167,6 @@ class NormaJuridica(models.Model):
             'numero': self.numero,
             'data': defaultfilters.date(self.data, "d \d\e F \d\e Y")}
 
-    def delete(self, using=None, keep_parents=False):
-        if self.texto_integral:
-            self.texto_integral.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
-
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
 
@@ -197,7 +191,8 @@ class NormaEstatisticas(models.Model):
         blank=True, null=True,
         auto_now=True)
     norma = models.ForeignKey(NormaJuridica,
-                             on_delete=models.CASCADE)
+                              on_delete=models.CASCADE)
+
     def __str__(self):
         return _('Usuário: %(usuario)s, Norma: %(norma)s') % {
             'usuario': self.usuario, 'norma': self.norma}
@@ -224,6 +219,7 @@ class AutoriaNorma(models.Model):
     def __str__(self):
         return _('Autoria: %(autor)s - %(norma)s') % {
             'autor': self.autor, 'norma': self.norma}
+
 
 @reversion.register()
 class LegislacaoCitada(models.Model):
@@ -271,8 +267,8 @@ class TipoVinculoNormaJuridica(models.Model):
     descricao_passiva = models.CharField(
         max_length=50, blank=True, verbose_name=_('Descrição Passiva'))
     revoga_integralmente = models.BooleanField(verbose_name=_('Revoga Integralmente?'),
-                                              choices=YES_NO_CHOICES,
-                                              default=False)
+                                               choices=YES_NO_CHOICES,
+                                               default=False)
 
     class Meta:
         verbose_name = _('Tipo de Vínculo entre Normas Jurídicas')
@@ -318,8 +314,8 @@ class AnexoNormaJuridica(models.Model):
         on_delete=models.PROTECT,
         verbose_name=_('Norma Juridica'))
     assunto_anexo = models.TextField(
-        blank = True,
-        default = "",
+        blank=True,
+        default="",
         verbose_name=_('Assunto do Anexo'),
         max_length=250
     )

--- a/sapl/parlamentares/models.py
+++ b/sapl/parlamentares/models.py
@@ -1,10 +1,10 @@
 
-import reversion
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from image_cropping.fields import ImageCropField, ImageRatioField
 from model_utils import Choices
+import reversion
 
 from sapl.base.models import Autor
 from sapl.decorators import vigencia_atual
@@ -303,13 +303,6 @@ class Parlamentar(models.Model):
     def avatar_html(self):
         return '<img class="avatar-parlamentar" src='\
             + self.fotografia.url + '>'if self.fotografia else ''
-
-    def delete(self, using=None, keep_parents=False):
-        if self.fotografia:
-            self.fotografia.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
 
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):

--- a/sapl/protocoloadm/models.py
+++ b/sapl/protocoloadm/models.py
@@ -1,8 +1,8 @@
-import reversion
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 from model_utils import Choices
+import reversion
 
 from sapl.base.models import Autor
 from sapl.materia.models import TipoMateriaLegislativa, UnidadeTramitacao
@@ -162,13 +162,6 @@ class DocumentoAdministrativo(models.Model):
             'tipo': self.tipo, 'assunto': self.assunto
         }
 
-    def delete(self, using=None, keep_parents=False):
-        if self.texto_integral:
-            self.texto_integral.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
-
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
 
@@ -214,13 +207,6 @@ class DocumentoAcessorioAdministrativo(models.Model):
 
     def __str__(self):
         return self.nome
-
-    def delete(self, using=None, keep_parents=False):
-        if self.arquivo:
-            self.arquivo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
 
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
@@ -299,10 +285,12 @@ class TramitacaoAdministrativo(models.Model):
             'documento': self.documento, 'status': self.status
         }
 
+
 @reversion.register()
 class AcompanhamentoDocumento(models.Model):
     usuario = models.CharField(max_length=50)
-    documento = models.ForeignKey(DocumentoAdministrativo, on_delete=models.CASCADE)
+    documento = models.ForeignKey(
+        DocumentoAdministrativo, on_delete=models.CASCADE)
     email = models.EmailField(
         max_length=100, verbose_name=_('E-mail'))
     data_cadastro = models.DateField(auto_now_add=True)

--- a/sapl/sessao/models.py
+++ b/sapl/sessao/models.py
@@ -186,19 +186,6 @@ class SessaoPlenaria(models.Model):
             # XXX check if it shouldn't be legislatura.numero
             'legislatura_id': self.legislatura.numero}
 
-    def delete(self, using=None, keep_parents=False):
-        if self.upload_pauta:
-            self.upload_pauta.delete()
-
-        if self.upload_ata:
-            self.upload_ata.delete()
-
-        if self.upload_anexo:
-            self.upload_anexo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
-
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
 
@@ -576,7 +563,8 @@ class ResumoOrdenacao(models.Model):
     oitavo = models.CharField(max_length=30)
     nono = models.CharField(max_length=30)
     decimo = models.CharField(max_length=30)
-    decimo_primeiro = models.CharField(max_length=30,default="Ocorrências da Sessão")
+    decimo_primeiro = models.CharField(
+        max_length=30, default="Ocorrências da Sessão")
 
     class Meta:
         verbose_name = _('Ordenação do Resumo de uma Sessão')
@@ -584,6 +572,7 @@ class ResumoOrdenacao(models.Model):
 
     def __str__(self):
         return 'Ordenação do Resumo de uma Sessão'
+
 
 @reversion.register()
 class TipoRetiradaPauta(models.Model):
@@ -651,13 +640,6 @@ class JustificativaAusencia(models.Model):
     def __str__(self):
         return 'Justificativa de Ausência'
 
-    def delete(self, using=None, keep_parents=False):
-        if self.upload_anexo:
-            self.upload_anexo.delete()
-
-        return models.Model.delete(
-            self, using=using, keep_parents=keep_parents)
-
     def save(self, force_insert=False, force_update=False, using=None,
              update_fields=None):
 
@@ -675,6 +657,7 @@ class JustificativaAusencia(models.Model):
                                  force_update=force_update,
                                  using=using,
                                  update_fields=update_fields)
+
 
 class RetiradaPauta(models.Model):
     materia = models.ForeignKey(MateriaLegislativa,


### PR DESCRIPTION
Issue #26 trata do django-reversion.

## Descrição
Atualmente o django-admin possui as funcionalidades para visualização de histórico, reversão e recuperação de versões modificadas e/ou excluídas, no entanto (como foi questionado aqui: https://github.com/interlegis/sapl/issues/26#issuecomment-379263831), da forma como os metodos delete dos models que possui FileField estão, os arquivos estão sendo apagado em definitivo, quebrando assim, o controle e versionamento dos arquivos adicionados em qualquer FileField.

Este PR elimina todas as remoções em definitivo de arquivos do sapl, com isso, arquivos trocados em qualquer FileField, limpos através do checkbox "limpar" e/ou com registro excluído, não serão removidos do FileSystem.

Este PR também cria um Management Command que, como o deleterevisions do django-reversion, será responsável para fazer pack no FileSystem.
