### PR TITLE
Fix typo Retidara

### DIFF
--- a/sapl/sessao/migrations/0028_auto_20181031_0902.py
+++ b/sapl/sessao/migrations/0028_auto_20181031_0902.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'verbose_name_plural': 'Tipos de Retirada de Pauta',
-                'verbose_name': 'Tipo de Retidara de Pauta',
+                'verbose_name': 'Tipo de Retirada de Pauta',
                 'ordering': ['descricao'],
             },
         ),

--- a/sapl/sessao/models.py
+++ b/sapl/sessao/models.py
@@ -590,7 +590,7 @@ class TipoRetiradaPauta(models.Model):
     descricao = models.CharField(max_length=150, verbose_name=_('Descrição'))
 
     class Meta:
-        verbose_name = _('Tipo de Retidara de Pauta')
+        verbose_name = _('Tipo de Retirada de Pauta')
         verbose_name_plural = _('Tipos de Retirada de Pauta')
         ordering = ['descricao']
 


### PR DESCRIPTION
Conserto da string `Retidara` para `Retirada`

Em ` sapl/sessao/models.py` e em `sapl/sessao/migrations/0028_auto_20181031_0902.py` há o erro de digitação, corrigido no PR.

Corrige a issue #2494