### PR TITLE
Permite periodos de composicao com mais de um ano

### DIFF
--- a/sapl/materia/views.py
+++ b/sapl/materia/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.core.urlresolvers import reverse
-from django.db.models import Max
+from django.db.models import Max, Q
 from django.http import HttpResponse, JsonResponse
 from django.http.response import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
@@ -1126,12 +1126,17 @@ class RelatoriaCrud(MasterDetailCrud):
 
                 materia = MateriaLegislativa.objects.get(
                     pk=self.kwargs.get('pk'))
-                ano_materia = materia.ano
+                data_materia = materia.data_apresentacao
 
                 comissao = Comissao.objects.get(
                     pk=context['form'].initial['comissao'])
                 composicao = comissao.composicao_set.filter(
-                    periodo__data_inicio__year=ano_materia)
+                        Q(periodo__data_fim__isnull=False,
+                          periodo__data_inicio__lte=data_materia,
+                          periodo__data_fim__gte=data_materia) |
+                        Q(periodo__data_fim__isnull=True,
+                          periodo__data_inicio__lte=data_materia)
+                    )
 
                 participacoes = Participacao.objects.select_related().filter(composicao=composicao)
 


### PR DESCRIPTION
Atualmente a relatória só permite períodos de um ano somente.

## Descrição
Esse fix visa permitir a relatoria de períodos com mais de um ano.

## Motivação e Contexto
Algumas casas possuem relatorias para comissões permanentes ou com mais de um ano.

## Como Isso Foi Testado?
Manualmente.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.