### PR TITLE
Replaced default alpine image with one that removes AAAA dns queries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM geekidea/alpine-a:3.8
 
 ENV BUILD_PACKAGES postgresql-dev graphviz-dev graphviz build-base git pkgconfig \
                    python3-dev libxml2-dev jpeg-dev libressl-dev libffi-dev libxslt-dev \


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
A imagem base do Alpine Linux tem problemas na resolução de nomes DNS em infraestruturas Kubernetes (e Rancher 1.6 também, em menor grau). O fato é que um problema (race condition) no módulo conntrack do kernel do linux versão 4.x causa timeouts na resolução de nomes concorrente, quando se faz mais de uma consulta ao mesmo tempo, caso do Alpine Linux com sua musl libc, para consultas IPv4 e IPv6 simultâneas.

O workaround aplicado faz um patch na bibiloteca "/lib/ld-musl-x86_64.so.1" do Alpine para que ele não faça mais consultas DNS IPv6. Referência:

https://github.com/kubernetes/kubernetes/issues/56903#issuecomment-409603030 


## Como Isso Foi Testado?
Testei no ambiente Kubernetes do Interlegis, por meio de sucessivas tentantivas de resolução de nomes.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [X] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)