### PR TITLE
Fix #2850 - Ordenação de content type

### DIFF
--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -1456,7 +1456,8 @@ class TipoProposicaoForm(ModelForm):
 
         self.fields['content_type'].choices = [
             (ct.pk, ct) for k, ct in content_types.items()]
-        self.fields['content_type'].choices.sort(key=lambda x: str(x[1]))
+        # Ordena por id
+        self.fields['content_type'].choices.sort(key=lambda x: x[0])
 
         if self.instance.pk:
             self.fields[


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
<!--- Decreva suas alterações detalhadamente -->
Anteriormente, as opções estavam sendo ordenadas por nome, o que causava Tipo Documento aparecer antes de Tipo Matéria. Agora, está ordenando por id.

## _Issue_ Relacionada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Se está sugerindo uma nova _feature_ ou mudança, por favor discuta em uma _issue_ antes. -->
<!--- Se está corrigindo um _bug_, deve haver uma _issue_ descrevendo-o com passos para reproduzir. -->
<!--- Por favor, adicione o link para a _issue_ aqui: -->
#2850 

## Motivação e Contexto
<!--- Por que essa mudança é necessária? Qual problema ela resolve? -->
Solicitação de usuário.

## Como Isso Foi Testado?
<!--- Por favor, descreva detalhadamente como você testou suas mudanças. -->
<!--- Inclua detalhes do seu ambiente de teste e os testes que você executou -->
<!--- para ver como a sua alteração afeta outras áreas do código, etc. -->
Manualmente.


## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [X] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [X] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [X] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [X] Todos os testes novos e existentes passaram.