### PR TITLE
Retira trava de ano e data de apresentação diferentes em Norma e Matéria

### DIFF
--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -156,25 +156,6 @@ class MateriaSimplificadaForm(FileFieldCheckMixin, ModelForm):
         )
         super(MateriaSimplificadaForm, self).__init__(*args, **kwargs)
 
-    def clean(self):
-        super(MateriaSimplificadaForm, self).clean()
-
-        if not self.is_valid():
-            return self.cleaned_data
-
-        cleaned_data = self.cleaned_data
-
-        data_apresentacao = cleaned_data['data_apresentacao']
-        ano = cleaned_data['ano']
-
-        if data_apresentacao.year != ano:
-            self.logger.error("O ano da matéria ({}) é diferente"
-                              " do ano na data de apresentação ({}).".format(ano, data_apresentacao.year))
-            raise ValidationError("O ano da matéria não pode ser "
-                                  "diferente do ano na data de apresentação")
-
-        return cleaned_data
-
 
 class MateriaLegislativaForm(FileFieldCheckMixin, ModelForm):
 
@@ -255,13 +236,6 @@ class MateriaLegislativaForm(FileFieldCheckMixin, ModelForm):
                                       .format(cleaned_data['tipo'], p.tipo_materia))
                     raise ValidationError(
                         _('Tipo do Protocolo deve ser o mesmo do Tipo Matéria'))
-
-        if data_apresentacao.year != ano:
-            self.logger.error("O ano da matéria ({}) é diferente "
-                              "do ano na data de apresentação ({})."
-                              .format(ano, data_apresentacao.year))
-            raise ValidationError(_("O ano da matéria não pode ser "
-                                    "diferente do ano na data de apresentação"))
 
         ano_origem_externa = cleaned_data['ano_origem_externa']
         data_origem_externa = cleaned_data['data_origem_externa']

--- a/sapl/norma/forms.py
+++ b/sapl/norma/forms.py
@@ -189,14 +189,6 @@ class NormaJuridicaForm(FileFieldCheckMixin, ModelForm):
         else:
             cleaned_data['materia'] = None
 
-        ano = cleaned_data['ano']
-        data = cleaned_data['data']
-
-        if data.year != ano:
-            self.logger.error("O ano da norma ({}) é diferente "
-                              "do ano no campo data ({}).".format(ano, data.year))
-            raise ValidationError("O ano da norma não pode ser "
-                                  "diferente do ano no campo data")
         return cleaned_data
 
     def clean_texto_integral(self):

--- a/sapl/templates/materia/materialegislativa_form.html
+++ b/sapl/templates/materia/materialegislativa_form.html
@@ -24,42 +24,88 @@
   $("#id_tipo, #id_ano").change(recuperar_numero_ano);
 
   function compare(a, b) {
-       if (a.text < b.text)
-         return -1;
-       if (a.text > b.text)
-         return 1;
-       return 0;
-     }
+    if (a.text < b.text)
+      return -1;
+    if (a.text > b.text)
+      return 1;
+    return 0;
+  }
 
-      $(document).ready(function() {
-          $("#id_tipo_autor").change(function() {
-              var tipo_selecionado = $("#id_tipo_autor").val();
-              var autor_selecionado = $("#id_autor").val();
-              $("#id_autor option").remove()
-              if (tipo_selecionado !== undefined && tipo_selecionado !== null) {
-                var json_data = {
-                   tipo : tipo_selecionado,
-                   data_relativa : $("#id_data_apresentacao").val()
-                }
-                $.getJSON("/api/autor/possiveis", json_data, function(data){
-                    if (data) {
-                      var results = data.sort(compare);
-                      if (results.length > 1) {
-                        $("#id_autor").append("<option>-----</option>");
-                      }
-                      $.each(results, function(idx, obj) {
-                          $("#id_autor")
-                            .append($("<option></option>")
-                            .attr("value", obj.value)
-                            .text(obj.text));
-                      });
-                      $("#id_autor").val(autor_selecionado);
-                    }
-                });
+  var modal_estilos = 'display: block;'
+    +'width: 85%; max-width: 600px;'
+    +'background: #fff; padding: 15px;'
+    +'border-radius: 5px;'
+    +'-webkit-box-shadow: 0px 6px 14px -2px rgba(0,0,0,0.75);'
+    +'-moz-box-shadow: 0px 6px 14px -2px rgba(0,0,0,0.75);'
+    +'box-shadow: 0px 6px 14px -2px rgba(0,0,0,0.75);'
+    +'position: fixed;'
+    +'top: 50%; left: 50%;'
+    +'transform: translate(-50%,-50%);'
+    +'z-index: 99999999; text-align: center';
+
+  var fundo_modal_estilos = 'top: 0; right: 0;'
+    +'bottom: 0; left: 0; position: fixed;'
+    +'background-color: rgba(0, 0, 0, 0.6); z-index: 99999999;'
+    +'display: none;';
+
+  var meu_modal = '<div id="fundo_modal" style="'+fundo_modal_estilos+'">'
+    +'<div id="meu_modal" style="'+modal_estilos+'">'
+      +'<h2>Atenção! Ano de apresentação e ano da matéria são diferentes.</h2><br />'
+      +'<button id="close_model_btn" type="button" class="btn btn-warning" data-dismiss="modal">'
+      +'Compreendo e quero continuar</button>'
+    +'</div></div>';
+
+  function verifica_ano(){
+    let ano = $("select#id_ano.select").val();
+    let data_apresentacao = $("input#id_data_apresentacao.dateinput").val();
+    let ano_apresentacao = data_apresentacao.substr(data_apresentacao.length - 4);
+    
+    if(ano && ano_apresentacao && ano_apresentacao != ano){
+      $('#fundo_modal').fadeIn();
+    }
+  }
+
+  $(document).ready(function() {
+    $("#id_tipo_autor").change(function() {
+      var tipo_selecionado = $("#id_tipo_autor").val();
+      var autor_selecionado = $("#id_autor").val();
+      $("#id_autor option").remove()
+      if (tipo_selecionado !== undefined && tipo_selecionado !== null) {
+        var json_data = {
+            tipo : tipo_selecionado,
+            data_relativa : $("#id_data_apresentacao").val()
+        }
+        $.getJSON("/api/autor/possiveis", json_data, function(data){
+          if (data) {
+            var results = data.sort(compare);
+            if (results.length > 1) {
+              $("#id_autor").append("<option>-----</option>");
             }
-          });
-          $("#id_tipo_autor").trigger('change');
-      });
+            $.each(results, function(idx, obj) {
+              $("#id_autor")
+                .append($("<option></option>")
+                .attr("value", obj.value)
+                .text(obj.text));
+            });
+            $("#id_autor").val(autor_selecionado);
+          }
+        });
+      }
+    });
+    $("#id_tipo_autor").trigger('change');
+
+    $("body").append(meu_modal);
+
+    $("#fundo_modal, #close_model_btn").click(function(){ $("#fundo_modal").hide(); });
+    $("#meu_modal").click(function(e){ e.stopPropagation(); });
+
+    $("select#id_ano.select.form-control").blur(function(){
+      verifica_ano();
+    });
+    $("input#id_data_apresentacao.dateinput.form-control").blur(function(){
+      verifica_ano();
+    });
+  });
 </script>
 
 {% endblock %}

--- a/sapl/templates/norma/normajuridica_form.html
+++ b/sapl/templates/norma/normajuridica_form.html
@@ -57,6 +57,54 @@
             numeroField.val(numero.replace(/^0+/, ''));
          }
   });
+
+  var modal_estilos = 'display: block;'
+    +'width: 85%; max-width: 600px;'
+    +'background: #fff; padding: 15px;'
+    +'border-radius: 5px;'
+    +'-webkit-box-shadow: 0px 6px 14px -2px rgba(0,0,0,0.75);'
+    +'-moz-box-shadow: 0px 6px 14px -2px rgba(0,0,0,0.75);'
+    +'box-shadow: 0px 6px 14px -2px rgba(0,0,0,0.75);'
+    +'position: fixed;'
+    +'top: 50%; left: 50%;'
+    +'transform: translate(-50%,-50%);'
+    +'z-index: 99999999; text-align: center';
+
+  var fundo_modal_estilos = 'top: 0; right: 0;'
+    +'bottom: 0; left: 0; position: fixed;'
+    +'background-color: rgba(0, 0, 0, 0.6); z-index: 99999999;'
+    +'display: none;';
+
+  var meu_modal = '<div id="fundo_modal" style="'+fundo_modal_estilos+'">'
+    +'<div id="meu_modal" style="'+modal_estilos+'">'
+      +'<h2>Atenção! Ano de apresentação e ano da norma são diferentes.</h2><br />'
+      +'<button id="close_model_btn" type="button" class="btn btn-warning" data-dismiss="modal">'
+      +'Compreendo e quero continuar</button>'
+    +'</div></div>';
+
+  function verifica_ano(){
+    let ano = $("select#id_ano.select").val();
+    let data_apresentacao = $("input#id_data.dateinput").val();
+    let ano_apresentacao = data_apresentacao.substr(data_apresentacao.length - 4);
+    
+    if(ano && ano_apresentacao && ano_apresentacao != ano){
+      $('#fundo_modal').fadeIn();
+    }
+  }
+
+  $(document).ready(function() {
+    $("body").append(meu_modal);
+
+    $("#fundo_modal, #close_model_btn").click(function(){ $("#fundo_modal").hide(); });
+    $("#meu_modal").click(function(e){ e.stopPropagation(); });
+
+    $("select#id_ano.select.form-control").blur(function(){
+      verifica_ano();
+    });
+    $("input#id_data.dateinput.form-control").blur(function(){
+      verifica_ano();
+    });
+  });
 </script>
 
 {% endblock %}


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
<!--- Decreva suas alterações detalhadamente -->
Retira trava que impedia que ano e ano da data de apresentação fossem diferentes em NormaJuridica e MateriaLegislativa. Um modal de aviso é exibido quando esses campos são diferentes, mas o usuário pode continuar normalmente.

## _Issue_ Relacionada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Se está sugerindo uma nova _feature_ ou mudança, por favor discuta em uma _issue_ antes. -->
<!--- Se está corrigindo um _bug_, deve haver uma _issue_ descrevendo-o com passos para reproduzir. -->
<!--- Por favor, adicione o link para a _issue_ aqui: -->
Chamado #460744

## Motivação e Contexto
<!--- Por que essa mudança é necessária? Qual problema ela resolve? -->
Vide chamado anterior.

## Como Isso Foi Testado?
<!--- Por favor, descreva detalhadamente como você testou suas mudanças. -->
<!--- Inclua detalhes do seu ambiente de teste e os testes que você executou -->
<!--- para ver como a sua alteração afeta outras áreas do código, etc. -->
Manualmente.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [ ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [X] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [X] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [X] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [X] Todos os testes novos e existentes passaram.