### PR TITLE
"conserta" horário de verão

### DIFF
--- a/sapl/painel/views.py
+++ b/sapl/painel/views.py
@@ -290,7 +290,10 @@ def votante_view(request):
 
 @user_passes_test(check_permission)
 def painel_view(request, pk):
-    context = {'head_title': str(_('Painel Plenário')), 'sessao_id': pk}
+    now = timezone.localtime(timezone.now())
+    utc_offset = now.utcoffset().total_seconds() / 60
+
+    context = {'head_title': str(_('Painel Plenário')), 'sessao_id': pk, 'utc_offset': utc_offset }
     return render(request, 'painel/index.html', context)
 
 

--- a/sapl/templates/painel/index.html
+++ b/sapl/templates/painel/index.html
@@ -33,7 +33,6 @@
         }
       }
     </style>
-
   </head>
   <body class="painel-principal">
       <audio type="hidden" id="audio" src="{% webpack_static 'audio/ring.mp3' %}"></audio>
@@ -110,7 +109,7 @@
           </div>
         </div>
       </div>
-
+      <input type="hidden" id="utc_offset" value="{{utc_offset}}"/>
       </div>
   </body>
 
@@ -124,24 +123,40 @@
   {% endblock webpack_loader_chunks_js %}
 
   <script type="text/javascript">
-    var d = new Date();
-    var n = d.toLocaleDateString();
-    document.getElementById("date").innerHTML = n;
 
       $(document).ready(function() {
+
+         // As constantes decisões sobre a existência ou não do horário de verão,
+         // assim como que data começa ou termina, fizeram com que fosse necessário
+         // substituir a chamada a Date() por um esquema mais elaborado, onde se
+         // recupera o offset do UTC (-3 GMT, no caso de Brasília) e seta-se
+         // manualmente. Esta informação vem do servidor, desta forma não ficamos
+         // na dependência da atualização de browser, pois tanto o Date() em JS
+         // quanto as libs python (django.utils.timezone, datetime, pytz, etc)
+         // lêem do tzdata, que precisa ser atualizado toda vez que o governo
+         // brasileiro modifica alguma coisa relacionada ao horário de verão.
+         // Recuperando essa informação do servidor só teremos que atualizar as
+         // libs tzdata (Linux) e pytz (Python) uma vez. Além disso, o uso da
+         // biblioteca moment.js é recomendada, pois ela trata data e hora
+         // melhor que o Date() do JS.
+
+         $("#date").append(moment().format("DD/MM/YY"));
+
+         var utc_offset = $("#utc_offset").val()
+
+         if (utc_offset !== undefined && utc_offset !== '') {
+            utc_offset = parseFloat(utc_offset);
+         }
+
          //TODO: replace by a fancy jQuery clock
          function checkTime(i) {
              if (i<10) {i = "0" + i};  // add zero in front of numbers < 10
                 return i;
          }
+
          function startTime() {
-             var today=new Date();
-             var h=today.getHours();
-             var m=today.getMinutes();
-             var s=today.getSeconds();
-             m = checkTime(m);
-             s = checkTime(s);
-             $("#relogio").text(h+":"+m+":"+s)
+             var today = moment.utc().utcOffset(utc_offset).format("HH:mm:ss");
+             $("#relogio").text(today)
              var t = setTimeout(function(){
                  startTime()
              }, 500);

--- a/sapl/templates/painel/index.html
+++ b/sapl/templates/painel/index.html
@@ -109,7 +109,6 @@
           </div>
         </div>
       </div>
-      <input type="hidden" id="utc_offset" value="{{utc_offset}}"/>
       </div>
   </body>
 
@@ -127,7 +126,7 @@
       $(document).ready(function() {
 
          // As constantes decisões sobre a existência ou não do horário de verão,
-         // assim como que data começa ou termina, fizeram com que fosse necessário
+         // assim como que data de início e termino do mesmo, fizeram com que fosse necessário
          // substituir a chamada a Date() por um esquema mais elaborado, onde se
          // recupera o offset do UTC (-3 GMT, no caso de Brasília) e seta-se
          // manualmente. Esta informação vem do servidor, desta forma não ficamos
@@ -142,11 +141,7 @@
 
          $("#date").append(moment().format("DD/MM/YY"));
 
-         var utc_offset = $("#utc_offset").val()
-
-         if (utc_offset !== undefined && utc_offset !== '') {
-            utc_offset = parseFloat(utc_offset);
-         }
+         var offset = parseFloat({{ utc_offset }});
 
          //TODO: replace by a fancy jQuery clock
          function checkTime(i) {
@@ -155,7 +150,7 @@
          }
 
          function startTime() {
-             var today = moment.utc().utcOffset(utc_offset).format("HH:mm:ss");
+             var today = moment.utc().utcOffset(offset).format("HH:mm:ss");
              $("#relogio").text(today)
              var t = setTimeout(function(){
                  startTime()


### PR DESCRIPTION
A revogação do horário de verão fez com que as horas no browser ficassem adiantadas em 1 hora. Isso também ocorria no servidor com as libs python (datetime e django.utils.timezone), mas isso foi consertando ao se atualizar as libs tzdata (Linux) e pytz (python). No entanto, como os browsers tem uma engine própria de JavaScript, seria necessário aguardar uma atualização deles. 

Além disso, o Date() do JS não permite setar a hora que gostaríamos. Por essa razão, este PR faz uso da lib momentjs e pega o offset do timezone do servidor para mostrar corretamente o horário.

<!--- Por favor, adicione o link para a _issue_ aqui: -->

## Motivação e Contexto
O relógio do Painel mostra uma hora a mais.

## Como Isso Foi Testado?
Manualmente.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código desse projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.