### PR TITLE
3144 - Checkbox de apenas leitura duplicado em matérias

### DIFF
--- a/sapl/sessao/forms.py
+++ b/sapl/sessao/forms.py
@@ -307,8 +307,6 @@ class ExpedienteMateriaForm(ModelForm):
         initial=datetime.strftime(timezone.now(), '%d/%m/%Y'),
         widget=forms.TextInput(attrs={'readonly': 'readonly'}))
 
-    apenas_leitura = forms.BooleanField(label='Apenas Leitura', required=False)
-
     class Meta:
         model = ExpedienteMateria
         fields = ['data_ordem', 'numero_ordem', 'tipo_materia', 'observacao',

--- a/sapl/templates/sessao/expedientemateria_form.html
+++ b/sapl/templates/sessao/expedientemateria_form.html
@@ -37,21 +37,6 @@
     $(fields[i]).change(recuperar_materia);
   }
   recuperar_materia();
-
-  $(document).ready(function(){
-    $("select[name='tipo_votacao']").children("option[value='4']").remove();
-    $('#id_apenas_leitura').change(function(event){
-      $('#div_id_tipo_votacao').toggle();
-      if($('#id_apenas_leitura').prop('checked')){
-        $("select[name='tipo_votacao']").append(new Option('Leitura', '4'));
-        $("select[name='tipo_votacao']").val('4');
-      }
-      else{
-        $("select[name='tipo_votacao']").children("option[value='4']").remove();
-        $("select[name='tipo_votacao']").val('1');
-      }
-    })
-  });
 </script>
 
 {% endblock %}

--- a/sapl/templates/sessao/layouts.yaml
+++ b/sapl/templates/sessao/layouts.yaml
@@ -59,7 +59,6 @@ ExpedienteMateria:
   - data_ordem numero_ordem
   - tipo_materia numero_materia ano_materia
   - tipo_votacao
-  - apenas_leitura
   - observacao
 
 OrdemDia:
@@ -67,7 +66,6 @@ OrdemDia:
   - data_ordem numero_ordem
   - tipo_materia numero_materia ano_materia
   - tipo_votacao
-  - apenas_leitura
   - observacao
 
 ExpedienteMateriaDetail:


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
<!--- Descreva suas alterações detalhadamente -->
Foi removido o checkbox de apenas leitura duplicado em Ordem do Dia e Expediente.

## _Issue_ Relacionada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Se está sugerindo uma nova _feature_ ou mudança, por favor discuta em uma _issue_ antes. -->
<!--- Se está corrigindo um _bug_, deve haver uma _issue_ descrevendo-o com passos para reproduzir. -->
<!--- Por favor, adicione o link para a _issue_ aqui: -->
Fix #3144 

## Capturas de Tela:
<!--- Insira imagens, se apropriado, da adição e/ou correção que foi feita -->
![Captura de Tela 2020-04-17 às 11 33 57](https://user-images.githubusercontent.com/21143590/79580407-55735a80-809f-11ea-967c-f2053c32814b.png)

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)
