### PR TITLE
3081 - Campos rotulo_prefixo_texto e rotulo_sufixo_texto como somente leitura

### DIFF
--- a/sapl/compilacao/admin.py
+++ b/sapl/compilacao/admin.py
@@ -1,3 +1,12 @@
+from django.contrib import admin
+from sapl.compilacao.models import TipoDispositivo
 from sapl.utils import register_all_models_in_admin
 
 register_all_models_in_admin(__name__)
+admin.site.unregister(TipoDispositivo)
+
+
+@admin.register(TipoDispositivo)
+class TipoDispositivoAdmin(admin.ModelAdmin):
+    readonly_fields = ("rotulo_prefixo_texto", "rotulo_sufixo_texto",)
+    list_display = [f.name for f in TipoDispositivo._meta.fields if f.name != 'id']


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
<!--- Descreva suas alterações detalhadamente -->
Altera rotulo_prefixo_texto e rotulo_sufixo_texto para somente leitura no DispositivoEdicaoBasicaForm

## _Issue_ Relacionada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Se está sugerindo uma nova _feature_ ou mudança, por favor discuta em uma _issue_ antes. -->
<!--- Se está corrigindo um _bug_, deve haver uma _issue_ descrevendo-o com passos para reproduzir. -->
<!--- Por favor, adicione o link para a _issue_ aqui: -->
Fix #3081 

## Captura de Telas
![Captura de Tela 2020-05-27 às 14 20 22](https://user-images.githubusercontent.com/21143590/83052119-3e704280-a025-11ea-83dd-fecc2d20e4d8.png)

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)