### PR TITLE
Corrige classificação dos logs de erros para logs de avisos

### DIFF
--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -211,10 +211,8 @@ class MateriaLegislativaForm(FileFieldCheckMixin, ModelForm):
 
         if protocolo:
             if not Protocolo.objects.filter(numero=protocolo, ano=ano).exists():
-                self.logger.error("Protocolo %s/%s não"
-                                  " existe" % (protocolo, ano))
-                raise ValidationError(_('Protocolo %s/%s não'
-                                        ' existe' % (protocolo, ano)))
+                self.logger.warning("Protocolo %s/%s não existe" % (protocolo, ano))
+                raise ValidationError(_('Protocolo %s/%s não existe' % (protocolo, ano)))
 
             if protocolo_antigo != protocolo:
                 exist_materia = MateriaLegislativa.objects.filter(
@@ -517,11 +515,9 @@ class TramitacaoForm(ModelForm):
                     raise ValidationError(msg)
 
             if cleaned_data['data_tramitacao'] > timezone.now().date():
-                self.logger.error('A data de tramitação informada ({}) não é ' +
-                                  'menor ou igual a data de hoje!'.format(cleaned_data['data_tramitacao']))
-                msg = _(
-                    'A data de tramitação deve ser ' +
-                    'menor ou igual a data de hoje!')
+                self.logger.warning('A data de tramitação informada ({}) não é menor ou igual a data de hoje!'
+                                    .format(cleaned_data['data_tramitacao']))
+                msg = _('A data de tramitação deve ser menor ou igual a data de hoje!')
                 raise ValidationError(msg)
 
             if (ultima_tramitacao and
@@ -535,10 +531,8 @@ class TramitacaoForm(ModelForm):
 
         if data_enc_form:
             if data_enc_form < data_tram_form:
-                msg = _('A data de encaminhamento deve ser ' +
-                        'maior que a data de tramitação!')
-                self.logger.error("A data de encaminhamento ({}) deve ser "
-                                  "maior que a data de tramitação! ({})"
+                msg = _('A data de encaminhamento deve ser maior que a data de tramitação!')
+                self.logger.warning("A data de encaminhamento ({}) deve ser maior que a data de tramitação! ({})"
                                   .format(data_enc_form, data_tram_form))
                 raise ValidationError(msg)
 
@@ -904,8 +898,7 @@ class AnexadaForm(ModelForm):
         except ObjectDoesNotExist:
             msg = _('A {} {}/{} não existe no cadastro de matérias legislativas.'
                     .format(cleaned_data['tipo'], cleaned_data['numero'], cleaned_data['ano']))
-            self.logger.error("A matéria a ser anexada não existe no cadastro"
-                              " de matérias legislativas.")
+            self.logger.warning("A matéria a ser anexada não existe no cadastro de matérias legislativas.")
             raise ValidationError(msg)
 
         materia_principal = self.instance.materia_principal
@@ -1742,11 +1735,9 @@ class TramitacaoEmLoteForm(ModelForm):
 
         if data_enc_form:
             if data_enc_form < data_tram_form:
-                self.logger.error('A data de encaminhamento ({}) deve ser '
-                                  'maior que a data de tramitação ({})!'
-                                  .format(data_enc_form, data_tram_form))
-                msg = _('A data de encaminhamento deve ser ' +
-                        'maior que a data de tramitação!')
+                self.logger.warning('A data de encaminhamento ({}) deve ser maior que a data de tramitação ({})!'
+                                    .format(data_enc_form, data_tram_form))
+                msg = _('A data de encaminhamento deve ser maior que a data de tramitação!')
                 raise ValidationError(msg)
 
         if data_prazo_form:

--- a/sapl/parlamentares/views.py
+++ b/sapl/parlamentares/views.py
@@ -585,8 +585,7 @@ class ParlamentarCrud(Crud):
                                   ". Tentando obter id da legislatura.")
                 return int(self.request.GET['pk'])
             except:
-                self.logger.error(
-                    "user=" + username + ". Legislatura não possui ID. Buscando em todas as entradas.")
+                self.logger.warning("User=" + username + ". Legislatura não possui ID. Buscando em todas as entradas.")
                 legislaturas = Legislatura.objects.all()
                 for l in legislaturas:
                     if l.atual():

--- a/sapl/protocoloadm/views.py
+++ b/sapl/protocoloadm/views.py
@@ -1368,9 +1368,9 @@ class TramitacaoAdmCrud(MasterDetailCrud):
 
             if tramitacao.pk != ultima_tramitacao.pk:
                 username = request.user.username
-                self.logger.error("user=" + username + ". Não é possível deletar a tramitação de pk={}. "
-                                  "Somente a última tramitação (pk={}) pode ser deletada!."
-                                  .format(tramitacao.pk, ultima_tramitacao.pk))
+                self.logger.warning("User={}. Não é possível deletar a tramitação de pk={}. "
+                                    "Somente a última tramitação (pk={}) pode ser deletada!."
+                                    .format(username, tramitacao.pk, ultima_tramitacao.pk))
                 msg = _('Somente a última tramitação pode ser deletada!')
                 messages.add_message(request, messages.ERROR, msg)
                 return HttpResponseRedirect(url)

--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -2801,8 +2801,8 @@ class VotacaoNominalAbstract(SessaoPermissionMixin):
                         parlamentar=parlamentar)
                 except ObjectDoesNotExist:
                     username = self.request.user.username
-                    self.logger.error('user=' + username + '. Objeto voto_parlamentar do ' +
-                                      'parlamentar de id={} não existe.'.format(parlamentar.pk))
+                    self.logger.warning('User={}. Objeto voto_parlamentar do parlamentar de id={} não existe.'
+                                        .format(username, parlamentar.pk))
                     yield [parlamentar, None]
                 else:
                     yield [parlamentar, voto.voto]
@@ -4398,8 +4398,8 @@ class VotacaoEmBlocoNominalView(PermissionRequiredForAppCrudMixin, TemplateView)
                         parlamentar=parlamentar)
                 except ObjectDoesNotExist:
                     username = self.request.user.username
-                    self.logger.error('user=' + username + '. Objeto voto_parlamentar do ' +
-                                      'parlamentar de id={} não existe.'.format(parlamentar.pk))
+                    self.logger.warning('User={}. Objeto voto_parlamentar do parlamentar de id={} não existe.'
+                                        .format(username, parlamentar.pk))
                     yield [parlamentar, None]
                 else:
                     yield [parlamentar, voto.voto]


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
<!--- Descreva suas alterações detalhadamente -->
A classificação de alguns logs de erros foram trocadas para logs de aviso por não serem erros do sistema, mas sim do usuário. Assim, o log ficará despoluído, podendo facilitar a identificação de erros do sistema.