### PR TITLE
Permite exclude em Meta de ModelSerializers customizados

### DIFF
--- a/sapl/api/serializers.py
+++ b/sapl/api/serializers.py
@@ -67,13 +67,9 @@ class ParlamentarSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Parlamentar
-        fields = ["id", "nome_completo",
-                  "nome_parlamentar", "sexo",
-                  "data_nascimento", "numero_gab_parlamentar",
-                  "telefone", "endereco_web",
-                  "profissao", "email",
-                  "locais_atuacao", "ativo",
-                  "biografia", "fotografia", "nivel_instrucao"]
+        exclude = ["fax", "endereco_residencia", "municipio_residencia",
+                   "uf_residencia", "cep_residencia", "telefone_residencia",
+                   "titulo_eleitor", "fax_residencia"]
 
 
 class ParlamentarResumeSerializer(serializers.ModelSerializer):

--- a/sapl/api/serializers.py
+++ b/sapl/api/serializers.py
@@ -72,6 +72,13 @@ class ParlamentarSerializer(serializers.ModelSerializer):
                    "titulo_eleitor", "fax_residencia"]
 
 
+class ParlamentarEditSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Parlamentar
+        fields = '__all__'
+
+
 class ParlamentarResumeSerializer(serializers.ModelSerializer):
     titular = serializers.SerializerMethodField('check_titular')
     partido = serializers.SerializerMethodField('check_partido')

--- a/sapl/api/serializers.py
+++ b/sapl/api/serializers.py
@@ -67,9 +67,10 @@ class ParlamentarSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Parlamentar
-        exclude = ["fax", "endereco_residencia", "municipio_residencia",
-                   "uf_residencia", "cep_residencia", "telefone_residencia",
-                   "titulo_eleitor", "fax_residencia"]
+        exclude = ["cpf", "rg", "fax",
+                   "endereco_residencia", "municipio_residencia",
+                   "uf_residencia", "cep_residencia", "situacao_militar",
+                   "telefone_residencia", "titulo_eleitor", "fax_residencia"]
 
 
 class ParlamentarEditSerializer(serializers.ModelSerializer):

--- a/sapl/api/views.py
+++ b/sapl/api/views.py
@@ -133,13 +133,14 @@ class SaplApiViewSetConstrutor():
                         if not hasattr(_meta_serializer, 'model'):
                             model = _model
 
-                        if not hasattr(_meta_serializer, 'fields'):
-                            fields = '__all__'
-                        elif _meta_serializer.fields != '__all__':
-                            fields = list(
-                                _meta_serializer.fields) + ['__str__', ]
-                        else:
-                            fields = _meta_serializer.fields
+                        if not hasattr(_meta_serializer, 'exclude'):
+                            if not hasattr(_meta_serializer, 'fields'):
+                                fields = '__all__'
+                            elif _meta_serializer.fields != '__all__':
+                                fields = list(
+                                    _meta_serializer.fields) + ['__str__', ]
+                            else:
+                                fields = _meta_serializer.fields
 
                     def get___str__(self, obj):
                         return str(obj)

--- a/sapl/api/views.py
+++ b/sapl/api/views.py
@@ -29,7 +29,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from sapl.api.forms import SaplFilterSetMixin
 from sapl.api.permissions import SaplModelPermissions
-from sapl.api.serializers import ChoiceSerializer, ParlamentarResumeSerializer
+from sapl.api.serializers import ChoiceSerializer, ParlamentarEditSerializer, ParlamentarResumeSerializer
 from sapl.base.models import Autor, AppConfig, DOC_ADM_OSTENSIVO
 from sapl.materia.models import Proposicao, TipoMateriaLegislativa,\
     MateriaLegislativa, Tramitacao
@@ -350,6 +350,10 @@ class _AutorViewSet:
 class _ParlamentarViewSet:
     class ParlamentarPermission(SaplModelPermissions):
         def has_permission(self, request, view):
+
+            if request.user.has_perm('parlamentares.add_parlamentar'):
+                self.serializer_class = ParlamentarEditSerializer
+
             if request.method == 'GET':
                 return True
             else:
@@ -426,7 +430,7 @@ class _ParlamentarViewSet:
 
 
 @customize(Proposicao)
-class _ProposicaoViewSet():
+class _ProposicaoViewSet:
     """
     list:
         Retorna lista de Proposições

--- a/sapl/api/views.py
+++ b/sapl/api/views.py
@@ -133,7 +133,9 @@ class SaplApiViewSetConstrutor():
                         if not hasattr(_meta_serializer, 'model'):
                             model = _model
 
-                        if not hasattr(_meta_serializer, 'exclude'):
+                        if hasattr(_meta_serializer, 'exclude'):
+                            exclude = _meta_serializer.exclude
+                        else:
                             if not hasattr(_meta_serializer, 'fields'):
                                 fields = '__all__'
                             elif _meta_serializer.fields != '__all__':


### PR DESCRIPTION
Atualmente o gerador de serializers automáticos não permite informar o campo exclude pois sempre tenta adicionar o atributo fields em Meta. 

## Descrição
Ditto.

## _Issue_ Relacionada
<!--- Este projeto apenas aceita _pull requests_ relacionadas à _issues_ abertas. -->
<!--- Se está sugerindo uma nova _feature_ ou mudança, por favor discuta em uma _issue_ antes. -->
<!--- Se está corrigindo um _bug_, deve haver uma _issue_ descrevendo-o com passos para reproduzir. -->
<!--- Por favor, adicione o link para a _issue_ aqui: -->

## Motivação e Contexto
Bug de segurança.

## Como Isso Foi Testado?
Manualmente.

## Capturas de Tela (se apropriado):
<!--- Insira imagens, se apropriado, da adição e/ou correção que foi feita -->

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.