### PR TITLE
Conserta bug em exibição de matéria lida em PDF

### DIFF
--- a/sapl/relatorios/views.py
+++ b/sapl/relatorios/views.py
@@ -626,18 +626,27 @@ def get_sessao_plenaria(sessao, casa):
         else:
             dic_expediente_materia["nom_autor"] = 'Desconhecido'
 
-        resultados = expediente_materia.registrovotacao_set.all()
-        if resultados:
-            for i in resultados:
-                dic_expediente_materia.update({
-                    "nom_resultado": i.tipo_resultado_votacao.nome,
-                    "votacao_observacao": i.observacao
-                })
+        rv = expediente_materia.registrovotacao_set.filter(
+            materia=expediente_materia.materia).first()
+        rp = expediente_materia.retiradapauta_set.filter(
+            materia=expediente_materia.materia).first()
+        if rv:
+            resultado = rv.tipo_resultado_votacao.nome
+            resultado_observacao = rv.observacao
+        elif rp:
+            resultado = rp.tipo_de_retirada.descricao
+            resultado_observacao = rp.observacao
         else:
-            dic_expediente_materia.update({
-                "nom_resultado": 'Matéria não votada',
-                "votacao_observacao": ' '
-            })
+            resultado = _('Matéria lida') \
+                if expediente_materia.tipo_votacao == 4 \
+                else _('Matéria não votada')
+            resultado_observacao = _(' ')
+
+        dic_expediente_materia.update({
+            "nom_resultado": resultado,
+            "votacao_observacao": resultado_observacao
+        })
+
         lst_expediente_materia.append(dic_expediente_materia)
 
     # Lista dos votos nominais das matérias do Expediente
@@ -723,15 +732,26 @@ def get_sessao_plenaria(sessao, casa):
         else:
             dic_votacao["nom_autor"] = 'Desconhecido'
 
-        dic_votacao["votacao_observacao"] = ' '
-        resultados = votacao.registrovotacao_set.all()
-        if resultados:
-            for i in resultados:
-                dic_votacao["nom_resultado"] = i.tipo_resultado_votacao.nome
-                if i.observacao:
-                    dic_votacao["votacao_observacao"] = i.observacao
+        rv = votacao.registrovotacao_set.filter(
+            materia=votacao.materia).first()
+        rp = votacao.retiradapauta_set.filter(
+            materia=votacao.materia).first()
+        if rv:
+            resultado = rv.tipo_resultado_votacao.nome
+            resultado_observacao = rv.observacao
+        elif rp:
+            resultado = rp.tipo_de_retirada.descricao
+            resultado_observacao = rp.observacao
         else:
-            dic_votacao["nom_resultado"] = "Matéria não votada"
+            resultado = _('Matéria lida') if \
+                votacao.tipo_votacao == 4 else _('Matéria não votada')
+            resultado_observacao = _(' ')
+
+        dic_votacao.update({
+            "nom_resultado": resultado,
+            "votacao_observacao": resultado_observacao
+        })
+
         lst_votacao.append(dic_votacao)
 
     # Lista dos votos nominais das matérias da Ordem do Dia

--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -1928,7 +1928,7 @@ def get_materias_expediente(sessao_plenaria):
                 tramitacao = aux_tramitacao
                 break
 
-        rv = m.registrovotacao_set.first()
+        rv = m.registrovotacao_set.filter(materia=m.materia).first()
         rp = m.retiradapauta_set.filter(materia=m.materia).first()
         if rv:
             resultado = rv.tipo_resultado_votacao.nome

--- a/sapl/templates/relatorios/blocos_sessao_plenaria/materias_expediente.html
+++ b/sapl/templates/relatorios/blocos_sessao_plenaria/materias_expediente.html
@@ -26,7 +26,10 @@
                             {% if materia.ordem_observacao %}<br><br>Obs.: {{materia.ordem_observacao}} {% endif %}
                         </div>
                     </td>
-                    <td style="text-align: center">&nbsp;<b>{{materia.nom_resultado}}</b></td>
+                    <td style="text-align: center">
+                        &nbsp;<b>{{materia.nom_resultado}}</b>
+                        <br><br>{{materia.votacao_observacao}}
+                    </td>
                 </tr>
             {% endfor %}
 

--- a/sapl/templates/relatorios/blocos_sessao_plenaria/materias_ordemdia.html
+++ b/sapl/templates/relatorios/blocos_sessao_plenaria/materias_ordemdia.html
@@ -24,7 +24,10 @@
                                 {% if materia.ordem_observacao %}<br><br>Obs.: {{materia.ordem_observacao}} {% endif %}
                             </div>
                         </td>
-                        <td style="text-align: center;">&nbsp;<b>{{materia.nom_resultado}}</b></td>
+                        <td style="text-align: center;">
+                            &nbsp;<b>{{materia.nom_resultado}}</b>
+                            <br><br>{{materia.votacao_observacao}}
+                        </td>
                     </tr>
                 {% endfor %}
 


### PR DESCRIPTION
Adiciona as opções 'matéria lida' e 'retirada de pauta' em relatório PDF de sessão plenária.

## Descrição
As opções de 'matéria lida' e 'matéria retirada de pauta' não apareciam na coluna Resultado do relatório de sessão plenária em PDF (constava como 'Não Votada').

## _Issue_ Relacionada
Não se aplica.

## Motivação e Contexto
Resolver um bug que omitia a retirada de pauta e a leitura de matéria do documento PDF de sessão plenária.

## Como Isso Foi Testado?
Manualmente.

## Capturas de Tela (se apropriado):
Não disponível.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.