### PR TITLE
Fixes #3344

### DIFF
--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -1984,6 +1984,10 @@ class ProposicaoForm(FileFieldCheckMixin, forms.ModelForm):
 
         cd = self.cleaned_data
 
+        texto_original = cd.get('texto_original', False)
+        if texto_original:
+            validar_arquivo(texto_original, 'Texto Original')
+
         tm, am, nm = (cd.get('tipo_materia', ''),
                       cd.get('ano_materia', ''),
                       cd.get('numero_materia', ''))


### PR DESCRIPTION
 Adiciona limite em nome de arquivo de proposição de acordo com configurações do resto do sistema.

## Descrição
 Adiciona limite em nome de arquivo de proposição de acordo com configurações do resto do sistema.

## _Issue_ Relacionada
Não se aplica.

## Motivação e Contexto
Evitar que parlamentares adicionem nomes de arquivos muito grandes.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x]_Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.