### PR TITLE
3365 filefield obrigatorio

### DIFF
--- a/sapl/comissoes/forms.py
+++ b/sapl/comissoes/forms.py
@@ -514,7 +514,7 @@ class DocumentoAcessorioCreateForm(FileFieldCheckMixin, forms.ModelForm):
         if not self.is_valid():
             return self.cleaned_data
 
-        arquivo = self.cleaned_data.get('arquivo', False)
+        arquivo = self.cleaned_data.get('arquivo')
 
         if arquivo:
             validar_arquivo(arquivo, "Texto Integral")
@@ -546,7 +546,7 @@ class DocumentoAcessorioEditForm(FileFieldCheckMixin, forms.ModelForm):
         if not self.is_valid():
             return self.cleaned_data
 
-        arquivo = self.cleaned_data.get('arquivo', False)
+        arquivo = self.cleaned_data.get('arquivo')
 
         if arquivo:
             validar_arquivo(arquivo, "Texto Integral")

--- a/sapl/comissoes/forms.py
+++ b/sapl/comissoes/forms.py
@@ -518,6 +518,12 @@ class DocumentoAcessorioCreateForm(FileFieldCheckMixin, forms.ModelForm):
 
         if arquivo:
             validar_arquivo(arquivo, "Texto Integral")
+        else:
+            ## TODO: definir arquivo no form e preservar o nome do campo
+            ## que gerou a mensagem de erro.
+            ## arquivo = forms.FileField(required=True, label="Texto Integral")
+            nome_arquivo = self.fields['arquivo'].label
+            raise ValidationError(f'Favor anexar arquivo em {nome_arquivo}')
 
         return self.cleaned_data
 
@@ -544,5 +550,11 @@ class DocumentoAcessorioEditForm(FileFieldCheckMixin, forms.ModelForm):
 
         if arquivo:
             validar_arquivo(arquivo, "Texto Integral")
+        else:
+            ## TODO: definir arquivo no form e preservar o nome do campo
+            ## que gerou a mensagem de erro.
+            ## arquivo = forms.FileField(required=True, label="Texto Integral")
+            nome_arquivo = self.fields['arquivo'].label
+            raise ValidationError(f'Favor anexar arquivo em {nome_arquivo}')
 
         return self.cleaned_data

--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -343,7 +343,7 @@ class DocumentoAcessorioForm(FileFieldCheckMixin, ModelForm):
         if not self.is_valid():
             return self.cleaned_data
 
-        arquivo = self.cleaned_data.get('arquivo', False)
+        arquivo = self.cleaned_data.get('arquivo')
 
         if arquivo:
             validar_arquivo(arquivo, "Texto Integral")

--- a/sapl/materia/forms.py
+++ b/sapl/materia/forms.py
@@ -347,6 +347,12 @@ class DocumentoAcessorioForm(FileFieldCheckMixin, ModelForm):
 
         if arquivo:
             validar_arquivo(arquivo, "Texto Integral")
+        else:
+            ## TODO: definir arquivo no form e preservar o nome do campo
+            ## que gerou a mensagem de erro.
+            ## arquivo = forms.FileField(required=True, label="Texto Integral")
+            nome_arquivo = self.fields['arquivo'].label
+            raise ValidationError(f'Favor anexar arquivo em {nome_arquivo}')
 
         return self.cleaned_data
 

--- a/sapl/materia/tests/test_materia.py
+++ b/sapl/materia/tests/test_materia.py
@@ -324,6 +324,10 @@ def test_documento_acessorio_submit(admin_client):
     tipo = baker.make(TipoDocumento,
                       descricao='Teste')
 
+    arquivo = SimpleUploadedFile("file.pdf",
+                                 b'conteudo do arquivo',
+                                 content_type="application/pdf")
+
     # Testa POST
     response = admin_client.post(reverse(
         'sapl.materia:documentoacessorio_create',
@@ -332,6 +336,7 @@ def test_documento_acessorio_submit(admin_client):
          'nome': 'teste_nome',
          'data_materia': '2016-03-21',
          'autor': autor,
+         'arquivo': arquivo,
          'ementa': 'teste_ementa',
          'data': '2016-03-21',
          'salvar': 'salvar'},

--- a/sapl/protocoloadm/forms.py
+++ b/sapl/protocoloadm/forms.py
@@ -641,7 +641,7 @@ class DocumentoAcessorioAdministrativoForm(FileFieldCheckMixin, ModelForm):
         if not self.is_valid():
             return self.cleaned_data
 
-        arquivo = self.cleaned_data.get('arquivo', False)
+        arquivo = self.cleaned_data.get('arquivo')
 
         if arquivo:
             validar_arquivo(arquivo, "Arquivo")
@@ -1181,10 +1181,17 @@ class DocumentoAdministrativoForm(FileFieldCheckMixin, ModelForm):
                                             ' documento vinculado'
                                             % (numero_protocolo, ano_protocolo)))
 
-        texto_integral = self.cleaned_data.get('texto_integral', False)
+        texto_integral = self.cleaned_data.get('texto_integral')
 
         if texto_integral:
             validar_arquivo(texto_integral, "Texto Integral")
+        else:
+            ## TODO: definir arquivo no form e preservar o nome do campo
+            ## que gerou a mensagem de erro.
+            ## texto_integral = forms.FileField(required=True, label="Texto Integral")
+            nome_arquivo = self.fields['texto_integral'].label
+            raise ValidationError(f'Favor anexar arquivo em {nome_arquivo}')
+
 
         return self.cleaned_data
 

--- a/sapl/protocoloadm/forms.py
+++ b/sapl/protocoloadm/forms.py
@@ -645,6 +645,12 @@ class DocumentoAcessorioAdministrativoForm(FileFieldCheckMixin, ModelForm):
 
         if arquivo:
             validar_arquivo(arquivo, "Arquivo")
+        else:
+            ## TODO: definir arquivo no form e preservar o nome do campo
+            ## que gerou a mensagem de erro.
+            ## arquivo = forms.FileField(required=True, label="Texto Integral")
+            nome_arquivo = self.fields['arquivo'].label
+            raise ValidationError(f'Favor anexar arquivo em {nome_arquivo}')
 
         return self.cleaned_data
 


### PR DESCRIPTION
Exigir que campo FileField seja obrigatório em Documentos Acessórios.

## Descrição
Exigir que campo FileField seja obrigatório em Documentos Acessórios.

## _Issue_ Relacionada
Fixes #3365

## Motivação e Contexto
Evitar a criação de registros de doc. acessório sem arquivo anexado.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.