### PR TITLE
Fixes #3382

### DIFF
--- a/sapl/materia/views.py
+++ b/sapl/materia/views.py
@@ -1241,14 +1241,21 @@ class HistoricoProposicaoView(PermissionRequiredMixin, ListView):
     ordering = ['-data_hora']
     paginate_by = 10
     model = HistoricoProposicao
-    permission_required = ('materia.detail_proposicao', )
+    permission_required = ('materia.detail_proposicao_enviada', )
 
     def get_queryset(self):
         qs = super().get_queryset()
+
+        from sapl.rules import SAPL_GROUP_AUTOR
+        from django.contrib.auth.models import Group
+
         user = self.request.user
-        if not user.is_superuser:
-            autores = Autor.objects.filter(user=user)
-            qs = qs.filter(proposicao__autor__in=autores)
+        grupo_autor = Group.objects.get(name=SAPL_GROUP_AUTOR)
+
+        if not user.is_superuser and grupo_autor.user_set.filter(
+                id=user.id).exists():
+           autores = Autor.objects.filter(user=user)
+           qs = qs.filter(proposicao__autor__in=autores)
         return qs
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Permite que usuários com permissão de acesso do tipo 'Operador Geral' ou 'Operador de Protocolo' possam visualizar o histórico de proposições. 

## Descrição
A tela só permitia que usuários admin tivesse possibilidade de ver, sinalizando com 404 todos os outros.

## _Issue_ Relacionada
#3356 

## Motivação e Contexto
Permitir que usuários que não sejam admin possam visualizar o histórico de proposições.

## Como Isso Foi Testado?
Manualmente.

## Capturas de Tela (se apropriado):
Não se aplica.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.