### PR TITLE
Adiciona checagem de HTML mal formado

### DIFF
--- a/sapl/compilacao/views.py
+++ b/sapl/compilacao/views.py
@@ -1093,6 +1093,7 @@ class DispositivoView(TextView):
 
 class TextEditView(CompMixin, TemplateView):
     template_name = 'compilacao/text_edit.html'
+    logger = logging.getLogger(__name__)
 
     def has_permission(self):
         self.object = self.ta
@@ -1112,6 +1113,13 @@ class TextEditView(CompMixin, TemplateView):
                 # TODO - implementar logging de ação de usuário
                 self.object.editing_locked = False
                 self.object.privacidade = STATUS_TA_EDITION
+                valid, error_msg = valida_html(self.object.ementa)
+                if not valid:
+                    messages.error(
+                        request, _('Texto mal formado %s', error_msg))
+                    return redirect(to=reverse_lazy(
+                        'sapl.compilacao:ta_text', kwargs={
+                            'ta_id': self.object.id}))
                 self.object.save()
                 messages.success(request, _(
                     'Texto Articulado desbloqueado com sucesso.'))
@@ -1142,11 +1150,25 @@ class TextEditView(CompMixin, TemplateView):
                 if 'lock' in request.GET:
                     self.object.editing_locked = True
                     self.object.privacidade = STATUS_TA_PUBLIC
+                    valid, error_msg = valida_html(self.object.ementa)
+                    if not valid:
+                        messages.error(
+                            request, _('Texto mal formado %s', error_msg))
+                        return redirect(to=reverse_lazy(
+                            'sapl.compilacao:ta_text_notificacoes', kwargs={
+                                'ta_id': self.object.id}))
                     self.object.save()
                     messages.success(request, _(
                         'Texto Articulado publicado com sucesso.'))
                 else:
                     self.object.temp_check_migrations = True
+                    valid, error_msg = valida_html(self.object.ementa)
+                    if not valid:
+                        messages.error(
+                            request, _('Texto mal formado %s', error_msg))
+                        return redirect(to=reverse_lazy(
+                            'sapl.compilacao:ta_text_notificacoes', kwargs={
+                                'ta_id': self.object.id}))
                     self.object.save()
                     messages.success(request, _(
                         'Texto Articulado Checado...'))
@@ -1369,6 +1391,9 @@ class TextEditView(CompMixin, TemplateView):
             e.inicio_vigencia = ta.data
             e.inicio_eficacia = ta.data
             e.texto = ta.ementa
+            valid, error_msg = valida_html(d.texto)
+            if not valid:
+                pass # TODO: mensagem de erro?
             e.dispositivo_pai = a
             e.save()
 
@@ -3024,6 +3049,9 @@ class DispositivoDinamicEditView(
 
             d_texto = d.texto
             d.texto = texto.strip()
+            valid, error_msg = valida_html(d.texto)
+            if not valid:
+                pass # TODO: mensagem de erro?
             d.texto_atualizador = texto_atualizador.strip()
 
             d.visibilidade = not visibilidade or visibilidade == 'True'
@@ -3521,3 +3549,17 @@ class TextNotificacoesView(CompMixin, ListView, FormView):
             type_notificacoes = [type_notificacoes, ]
 
         return self.get_notificacoes(result, type_notificacoes)
+
+
+def valida_html(html):
+    import logging
+    from lxml import etree
+    from io import StringIO
+    logger = logging.getLogger(__name__)
+    try:
+        if len(html.strip()) > 0:
+            etree.parse(StringIO(html), etree.HTMLParser(recover=False))
+        return True, None
+    except Exception as e:
+        logger.error("HTML mal formado %s (%s)", html, str(e))
+        return False, str(e)


### PR DESCRIPTION
Faz uma checagem de HTML mal formado durante o save() de Dispositivo em Textos Articulados. 

## Descrição
Algumas vezes, é possível que o usuário insira HTMLs mal formados seja por ação ou por vias de copia-e-cola.  A intenção deste PR é mitigar as chances disso ocorrer. 

## Motivação e Contexto
Diminuir a possibilidade de erro em textos articulados por conta de HTML mal formado. 

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.