### PR TITLE
[FIX] Security - useing Safeloader

### DIFF
--- a/sapl/legacy/migracao_usuarios.py
+++ b/sapl/legacy/migracao_usuarios.py
@@ -71,7 +71,7 @@ def migrar_usuarios(dir_repo):
 
     ARQUIVO_USUARIOS = Path(dir_repo).child('usuarios.yaml')
     with open(ARQUIVO_USUARIOS, 'r') as f:
-        usuarios = yaml.load(f, yaml.Loader)
+        usuarios = yaml.load(f, yaml.SafeLoader)
     # conferimos de que só há um nome de usuário
     assert all(nome == dados['name'] for nome, dados in usuarios.items())
     usuarios = [

--- a/sapl/legacy/scripts/ressuscita_dependencias.py
+++ b/sapl/legacy/scripts/ressuscita_dependencias.py
@@ -414,7 +414,7 @@ def get_ressuscitar(slug):
 def get_slug():
     arq = DIR_DADOS_MIGRACAO.child('siglas_para_slugs.yaml')
     with open(arq, 'r') as arq:
-        siglas_para_slugs = yaml.load(arq, yaml.Loader)
+        siglas_para_slugs = yaml.load(arq, yaml.SafeLoader)
     sigla = NOME_BANCO_LEGADO[-3:]
     return siglas_para_slugs[sigla]
 

--- a/sapl/legacy/scripts/ressuscita_dependencias.py
+++ b/sapl/legacy/scripts/ressuscita_dependencias.py
@@ -198,7 +198,7 @@ Para facilitar sua conferência, seguem os links para as proposições envolvida
 def get_dependencias_a_ressuscitar(slug):
     ocorrencias = yaml.load(
         Path(DIR_REPO.child('ocorrencias.yaml').read_file()),
-        yaml.Loader
+        yaml.SafeLoader
     )
     fks_faltando = ocorrencias.get('fk')
     if not fks_faltando:

--- a/sapl/legacy_migration_settings.py
+++ b/sapl/legacy_migration_settings.py
@@ -54,7 +54,7 @@ match = re.match('sapl_cm_(.*)', NOME_BANCO_LEGADO)
 SIGLA_CASA = match.group(1)
 _PATH_TABELA_TIMEZONES = DIR_DADOS_MIGRACAO.child('tabela_timezones.yaml')
 with open(_PATH_TABELA_TIMEZONES, 'r') as arq:
-    tabela_timezones = yaml.load(arq, yaml.Loader)
+    tabela_timezones = yaml.load(arq, yaml.SafeLoader)
 municipio, uf, nome_timezone = tabela_timezones[SIGLA_CASA]
 if nome_timezone:
     PYTZ_TIMEZONE = pytz.timezone(nome_timezone)

--- a/sapl/test_crispy_layout_mixin.py
+++ b/sapl/test_crispy_layout_mixin.py
@@ -18,7 +18,7 @@ ModelName:
   - highlander '''
 
     with mock.patch('sapl.crispy_layout_mixin.read_yaml_from_file') as ryff:
-        ryff.return_value = yaml.load(stub_content, yaml.Loader)
+        ryff.return_value = yaml.load(stub_content, yaml.SafeLoader)
         assert read_layout_from_yaml('....', 'ModelName') == [
             ['Cool Legend',
              [('name', 9),  ('place', 2), ('tiny', 1)],


### PR DESCRIPTION
Using SafeLoader instead of Loader to avoid security risks 

here is a example proof of concept  : 
![pocforloader](https://user-images.githubusercontent.com/36979660/136096450-7de00244-b5ea-4178-8070-2356163f2f32.png)

for using Loader 

and here is proof of fix :

![pofyaml](https://user-images.githubusercontent.com/36979660/136096621-616ea192-ae6a-48a5-ad08-58c25a7ddd3d.png)


**Hacktoberfest**
