### PR TITLE
Fecha votações abertas

### DIFF
--- a/sapl/sessao/views.py
+++ b/sapl/sessao/views.py
@@ -141,14 +141,20 @@ def verifica_votacoes_abertas(request):
                 v.__str__()))
         username = request.user.username
         logger.info('user=' + username + '. Já existem votações ou leituras abertas nas seguintes Sessões: ' +
-                    ', '.join(msg_abertas) + '. Para abrir '
-                    'outra, termine ou feche as votações ou leituras abertas.')
+                    ', '.join(msg_abertas) + '. Estas votações ou leituras foram fechadas.')
         msg = _('Já existem votações ou leituras abertas nas seguintes Sessões: ' +
-                ', '.join(msg_abertas) + '. Para abrir '
-                'outra, termine ou feche as votações ou leituras abertas.')
+                ', '.join(msg_abertas) + '. Estas votações ou leituras foram fechadas.')
         messages.add_message(request, messages.INFO, msg)
 
-        return False
+        for sessao in votacoes_abertas:
+            ordens = sessao.ordemdia_set.filter(votacao_aberta=True)
+            expediente = sessao.expedientemateria_set.filter(votacao_aberta=True)
+            for o in ordens:
+                o.votacao_aberta = False
+                o.save()
+            for e in expediente:
+                e.votacao_aberta = False
+                e.save()
 
     return True
 


### PR DESCRIPTION
Fecha votações de sessões anteriores ao abrir votação em nova sessão.

## Descrição
O SAPL bloqueava a abertura de votação caso houvesse alguma votação aberta em sessão anterior. Nem sempre era possível fechar a votação antiga devido a algum caso específico não identificado. Agora, ao abrir uma votação ou leitura, as atualmente abertas serão automaticamente fechadas.

## Motivação e Contexto
Diminuir a quantidade de chamados devido a votações abertas.

## Como Isso Foi Testado?
Manualmente.

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.