### PR TITLE
Feat: Ajuste de mensagem de erro de número de sessão plenária existente

### DIFF
--- a/sapl/sessao/forms.py
+++ b/sapl/sessao/forms.py
@@ -71,9 +71,9 @@ class SessaoPlenariaForm(FileFieldCheckMixin, ModelForm):
         encerramento = self.cleaned_data['data_fim']
 
         error = ValidationError(
-            "Número de Sessão Plenária já existente "
-            "para a Legislatura, Sessão Legislativa e Tipo informados. "
-            "Favor escolher um número distinto.")
+            "Número de Sessão Plenária '" + str(num) + "' já existente "
+            "para o Tipo de Sessão " + str(tipo) + " da " + str(sl) +
+            " Sessão Legislativa da " + str(leg) + " Legislatura. Por Favor, escolha um número distinto.")
 
         qs = tipo.build_predicados_queryset(leg, sl, abertura)
         qs &= Q(numero=num)


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
Ajuste de mensagem de erro exibida após tentativa de inclusão de sessão plenária com número já existente para o mesmo tipo/sessao/legislatura

## _Issue_ Relacionada
https://github.com/interlegis/sapl/issues/3609

## Motivação e Contexto
Exibir uma mensagem que retorne mais explicação e contexto, de forma que fique mais claro ao usuário a regra estabelecida internamente no sistema.

## Como Isso Foi Testado?
localmente

## Capturas de Tela (se apropriado):
![image](https://user-images.githubusercontent.com/100957576/192917685-00e11aba-01c9-4aad-93ef-115f9124dcc8.png)


## Tipos de Mudanças
- [x ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
- [ x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x ] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ x] Todos os testes novos e existentes passaram.