### PR TITLE
Altera nome completo para nome parlamentar em ata

### DIFF
--- a/sapl/templates/sessao/blocos_ata/lista_presenca_ordem_dia.html
+++ b/sapl/templates/sessao/blocos_ata/lista_presenca_ordem_dia.html
@@ -5,7 +5,7 @@
 	{% if presenca_ordem %}
 	<strong>Lista de Presença na Ordem do Dia: </strong>
 		{% for p in presenca_ordem %}
-			{{p.nome_completo}} / {% if p|filiacao_data_filter:object.data_inicio %} {{ p|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
+			{{p.nome_parlamentar}} / {% if p|filiacao_data_filter:object.data_inicio %} {{ p|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
 			{% if not forloop.last %} ; {% endif %}
 		{% endfor %}
 	{% endif %}

--- a/sapl/templates/sessao/blocos_ata/lista_presenca_sessao.html
+++ b/sapl/templates/sessao/blocos_ata/lista_presenca_sessao.html
@@ -5,7 +5,7 @@
     {% if presenca_sessao %}
       <strong>Lista de Presença na Sessão: </strong>
       {% for p in presenca_sessao %}
-          {{p.nome_completo}} / {% if p|filiacao_data_filter:object.data_inicio %} {{ p|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
+          {{p.nome_parlamentar}} / {% if p|filiacao_data_filter:object.data_inicio %} {{ p|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
       {% if not forloop.last %} ; {% endif %}
       {% endfor %}
     {% endif %}  
@@ -14,7 +14,7 @@
     {% if justificativa_ausencia %}
       <strong>Justificativas de Ausências na Sessão: </strong>
       {% for j in justificativa_ausencia %}
-          {{j.parlamentar.nome_completo}} / {{ j.tipo_ausencia }}
+          {{j.parlamentar.nome_parlamentar}} / {{ j.tipo_ausencia }}
       {% if not forloop.last %} ; {% endif %}
       {% endfor %}
     {% endif %}

--- a/sapl/templates/sessao/blocos_ata/mesa_diretora.html
+++ b/sapl/templates/sessao/blocos_ata/mesa_diretora.html
@@ -6,7 +6,7 @@
       <strong>Mesa Diretora: </strong>
       {% for m in mesa %}
         {{m.cargo}}:
-        {{m.parlamentar.nome_completo}} / {% if m.parlamentar|filiacao_data_filter:object.data_inicio %} {{ m.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %} 
+        {{m.parlamentar.nome_parlamentar}} / {% if m.parlamentar|filiacao_data_filter:object.data_inicio %} {{ m.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
         {% if not forloop.last %} ; {% endif %}
       {% endfor %}
     {% endif %}

--- a/sapl/templates/sessao/blocos_ata/oradores_expediente.html
+++ b/sapl/templates/sessao/blocos_ata/oradores_expediente.html
@@ -5,7 +5,7 @@
 	{% if oradores %}
     	<strong>Oradores do Expediente: </strong>
     	{% for o in oradores %}
-				<b>{{o.numero_ordem}}</b> - {{o.parlamentar.nome_completo}} / {% if o.parlamentar|filiacao_data_filter:object.data_inicio %} {{ o.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
+				<b>{{o.numero_ordem}}</b> - {{o.parlamentar.nome_parlamentar}} / {% if o.parlamentar|filiacao_data_filter:object.data_inicio %} {{ o.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
 				{% if o.url_discurso %} - <b>URL Vídeo:</b> <a href={{o.url_discurso}}>{{o.url_discurso}}</a>  {% endif %}
 				{% if o.observacao %} - <b>Observação:</b> {{o.observacao}} {% endif %}
 				{% if not forloop.last %} ; {% endif %}

--- a/sapl/templates/sessao/blocos_ata/oradores_explicacoes.html
+++ b/sapl/templates/sessao/blocos_ata/oradores_explicacoes.html
@@ -5,7 +5,7 @@
 	{% if oradores_explicacoes %}
     	<strong>Oradores das Explicações Pessoais: </strong>
 		{% for o in oradores_explicacoes %}
-	        <b>{{o.numero_ordem}}</b> - {{o.parlamentar.nome_completo}} / {% if o.parlamentar|filiacao_data_filter:object.data_inicio %} {{ o.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
+	        <b>{{o.numero_ordem}}</b> - {{o.parlamentar.nome_parlamentar}} / {% if o.parlamentar|filiacao_data_filter:object.data_inicio %} {{ o.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
 				{% if o.observacao %} - {{o.observacao}} {% endif %}
 			{% if not forloop.last %} ; {% endif %}
 		{% endfor %}

--- a/sapl/templates/sessao/blocos_ata/oradores_ordemdia.html
+++ b/sapl/templates/sessao/blocos_ata/oradores_ordemdia.html
@@ -5,7 +5,7 @@
 		{% if oradores_ordemdia %}
 			<strong>Oradores da Ordem do Dia: </strong>
 			{% for o in oradores_ordemdia %}
-				<b>{{o.numero_ordem}}</b> - {{o.parlamentar.nome_completo}} / {% if o.parlamentar|filiacao_data_filter:object.data_inicio %} {{ o.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
+				<b>{{o.numero_ordem}}</b> - {{o.parlamentar.nome_parlamentar}} / {% if o.parlamentar|filiacao_data_filter:object.data_inicio %} {{ o.parlamentar|filiacao_data_filter:object.data_inicio }} {% else %} Sem partido {% endif %}
 				{% if o.url_discurso %} - <b>URL Vídeo:</b> <a href={{o.url_discurso}}>{{o.url_discurso}}</a>  {% endif %}
 				{% if o.observacao %} - <b>Observação:</b> {{o.observacao}} {% endif %}
 				{% if not forloop.last %} ; {% endif %}


### PR DESCRIPTION
OSTicket: https://suporte.interlegis.leg.br/scp/tickets.php?id=50504

_"O SAPL está trazendo tipos de nomes de parlamentares diferentes na ata eletrônica das sessões em Sessão Plenária -> Extrato._

_Por exemplo: ao mencionar o vereador nas listas de presenças (da sessão ou da ordem do dia) o sistema exibe o nome político do parlamentar. Porém ao mencionar o mesmo vereador na autoria das proposições o sistema exibe o nome completo do mesmo._

_Seria possível padronizar o nome político do parlamentar em todas menções da Ata eletrônica gerada no extrato da sessão?"_

Foi deixado de fora as assinaturas, nas quais consta o nome completo. 