### PR TITLE
feat: Torna o campo Data Nascimento de Parlamentares sensivel

### DIFF
--- a/sapl/api/serializers.py
+++ b/sapl/api/serializers.py
@@ -86,7 +86,7 @@ class ParlamentarSerializerPublic(SaplSerializerMixin):
 
     class Meta:
         model = Parlamentar
-        exclude = ["cpf", "rg", "fax",
+        exclude = ["cpf", "rg", "fax", "data_nascimento",
                    "endereco_residencia", "municipio_residencia",
                    "uf_residencia", "cep_residencia", "situacao_militar",
                    "telefone_residencia", "titulo_eleitor", "fax_residencia"]

--- a/sapl/templates/parlamentares/parlamentar_perfil_publico.html
+++ b/sapl/templates/parlamentares/parlamentar_perfil_publico.html
@@ -37,12 +37,6 @@
 
       <div class="col-sm-8">
         <div id="div_data_nascimento" class="form-group">
-          <p><b>Data de Nascimento: </b> &nbsp {{object.data_nascimento|default_if_none:"Não informado"}}</p>
-        </div>
-      </div>
-
-      <div class="col-sm-8">
-        <div id="div_data_nascimento" class="form-group">
           <p><b>Telefone: </b> &nbsp {{object.telefone|default_if_none:"Não informado"}}</p>
         </div>
       </div>


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
- Alterado o serializador personalizado, ParlamentarSerializerPublic, para excluir o campo sensível data_nascimento da resposta da API.
- Alterado a view public, sapl/templates/parlamentares/parlamentar_perfil_publico.html, removendo o campo 

## _Issue_ Relacionada
Chamado #917987

## Motivação e Contexto
LGPD

## Como Isso Foi Testado?
Localmente

## Capturas de Tela (se apropriado):

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [ ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [x ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [ x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [ x] Meu código segue o estilo de código deste projeto.
- [x ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ x] Todos os testes novos e existentes passaram.