### PR TITLE
Conserta lógica para embutir SAPL em iframe

### DIFF
--- a/sapl/templates/base.html
+++ b/sapl/templates/base.html
@@ -267,7 +267,7 @@
       <script type="text/javascript" >
         function inIframe () {
           try {
-              return window.self !== window.top;
+              return window.location !== window.parent.location
           } catch (e) {
               return true;
           }


### PR DESCRIPTION
A inserção do SAPL dentro de iframes no PM parou de funcionar. Essa alteração visa consertar isso.