### PR TITLE
fix: restring acesso ao prometheus metrics para apenas ips locais/invalidos

### DIFF
--- a/sapl/endpoint_restriction_middleware.py
+++ b/sapl/endpoint_restriction_middleware.py
@@ -1,0 +1,38 @@
+from django.http import HttpResponseForbidden
+import logging
+
+# lista de IPs permitidos (localhost, redes locais, etc)
+# https://en.wikipedia.org/wiki/Reserved_IP_addresses
+ALLOWED_IPS = [
+    '127.0.0.1',
+    '::1',
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+    'fc00::/7',
+    '::1',
+    'fe80::/10',
+    '192.0.2.0/24',
+    '2001:db8::/32',
+    '224.0.0.0/4',
+    'ff00::/8'
+]
+
+RESTRICTED_ENDPOINTS = ['/metrics']
+
+
+class EndpointRestrictionMiddleware:
+    logging.getLogger(__name__)
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # IP do cliente
+        client_ip = request.META.get('REMOTE_ADDR')
+
+        # bloqueia acesso a endpoints restritos para IPs nao permitidos
+        if request.path in RESTRICTED_ENDPOINTS and client_ip not in ALLOWED_IPS:
+            return HttpResponseForbidden('Acesso proibido')
+
+        return self.get_response(request)

--- a/sapl/settings.py
+++ b/sapl/settings.py
@@ -128,6 +128,7 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'sapl.endpoint_restriction_middleware.EndpointRestrictionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',


### PR DESCRIPTION
## Descrição
Este pull request adiciona um novo middleware, `IpRestrictionMiddleware`, que restringe o acesso à rota "/metrics" do `django_prometheus` apenas a endereços IP locais. Essa medida de segurança adicional visa proteger o endpoint "/metrics" contra acessos não autorizados.

## _Issue_ Relacionada
problema pontuado em reuniao com SEIT (infra)

## Motivação e Contexto
Restringir acesso à informacao sensivel

## Como Isso Foi Testado?
localmente

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [ x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [ x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ x] Todos os testes novos e existentes passaram.