### PR TITLE
Conserta bug em relatórios com emenda longa.

### DIFF
--- a/sapl/static/sapl/css/relatorio.css
+++ b/sapl/static/sapl/css/relatorio.css
@@ -58,6 +58,7 @@ fieldset {
 
 
 table {
+    table-layout: fixed;
     max-width: 520px;
 }
 table.grayTable {
@@ -69,6 +70,10 @@ table.grayTable {
 table.grayTable td, table.grayTable th {
     border: 1px solid #000000;
     padding: 5px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    text-align: justify;
+    vertical-align: top;
 }
 table.grayTable tbody td {
     font-size: 10px;

--- a/sapl/templates/relatorios/relatorio_pauta_sessao.html
+++ b/sapl/templates/relatorios/relatorio_pauta_sessao.html
@@ -6,12 +6,17 @@
 
 {% block content %}
   <style>
+    table {
+      width:100%;
+      table-layout: fixed;
+    }
     table.grayTable tbody td {
       font-size: 10px;
       max-width: 80px;
       overflow-wrap: break-word;
       word-wrap: break-word;
-      text-align: initial;
+      text-align: justify;
+      vertical-align: top;
     }
   </style>
     <h2 class="gray-title">Identificação Básica</h2>
@@ -19,7 +24,7 @@
         {{ b }}<br/>
     {% endfor %}
     <h2 class="gray-title">Correspondências</h2>
-    <table class="grayTable">
+    <table style="table grayTable">
         <tbody>
             {% for c in correspondencias%}
                 <tr>

--- a/sapl/templates/sessao/blocos_resumo/materias_ordem_dia.html
+++ b/sapl/templates/sessao/blocos_resumo/materias_ordem_dia.html
@@ -1,4 +1,3 @@
-
 {% load common_tags %}
 {% if materias_ordem %}
 <fieldset>

--- a/sapl/templates/sessao/pauta_sessao_detail.html
+++ b/sapl/templates/sessao/pauta_sessao_detail.html
@@ -1,6 +1,6 @@
 {% extends "crud/detail.html" %}
 {% load i18n %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags common_tags%}
 
 {% block base_content %}
 	<div align=right><a href="{% url 'sapl.sessao:pauta_sessao_detail' object.pk %}pdf"> Impressão PDF</a></li></div>
@@ -64,7 +64,7 @@
 								<b>Autor{{ m.autor|length|pluralize:"es" }}</b>: {{ m.autor|join:', ' }}
 							</td>
 							<td style="width:60%;">
-								{{m.ementa|safe}}
+								{{m.ementa|dont_break_out}}
 								{% if m.observacao %}<br><br>Obs.: {{m.observacao}} {% endif %}
 							</td>
 							<td style="width:20%;">{{m.situacao|linebreaksbr|safe}}</td>
@@ -89,7 +89,7 @@
 							<b>Autor{{ m.autor|length|pluralize:"es" }}</b>: {{ m.autor|join:', ' }}
 						</td>
 						<td style="width:60%;">
-							{{m.ementa|safe}}
+							{{m.ementa|dont_break_out}}
 							{% if m.observacao %}<br><br>Obs.: {{m.observacao}} {% endif %}
 						</td>
 						<td style="width:20%;">{{m.situacao|linebreaksbr|safe}}</td>


### PR DESCRIPTION
Segundo reportado por Pato Branco - PR, quando inseridos textos longos na ementa, especialmente com caracteres HTML e formatação livre, a coluna de ementa "estoura". Este PR visa consertar isso. 