### PR TITLE
fix: altera nome do presidente no pdf de impressao da pauta de sessao para utilizar o nome_parlamentar

### DIFF
--- a/sapl/templates/relatorios/relatorio_pauta_sessao.html
+++ b/sapl/templates/relatorios/relatorio_pauta_sessao.html
@@ -94,7 +94,7 @@
         </br></br></br>
           <center>
           <div class="col-md-6">___________________________________________ </br>
-              <b>{{p.parlamentar.nome_completo}}</b> </br>{{p.cargo}}
+              <b>{{p.parlamentar.nome_parlamentar}}</b> </br>{{p.cargo}}
               </br></br></br>
           </div>
           </center>


### PR DESCRIPTION
## Descrição
O pdf de impressao da pauta de sessao cotinua o nome completo do presidente, ao inves do nome do parlamentar.

## _Issue_ Relacionada
chamado #840939

## Motivação e Contexto
consoante com demais areas do sistemas

## Como Isso Foi Testado?
localmente


## Tipos de Mudanças
- [x ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
- [x ] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [ x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ x] Todos os testes novos e existentes passaram.