### PR TITLE
fix: corrige render de texto rico no resumo de sessão

### DIFF
--- a/sapl/templates/relatorios/blocos_sessao_plenaria/consideracoes_finais.html
+++ b/sapl/templates/relatorios/blocos_sessao_plenaria/consideracoes_finais.html
@@ -1,4 +1,4 @@
     <h2 class="gray-title">Considerações Finais</h2>
     {% for c in lst_consideracoes%}
-            <p>{{c}}</p>
+            <p>{{c|safe}}</p>
     {% endfor %}

--- a/sapl/templates/relatorios/blocos_sessao_plenaria/ocorrencias_da_sessao.html
+++ b/sapl/templates/relatorios/blocos_sessao_plenaria/ocorrencias_da_sessao.html
@@ -1,4 +1,4 @@
     <h2 class="gray-title">Ocorrências da Sessão</h2>
     {% for o in lst_ocorrencias%}
-            <p>{{o}}</p>
+            <p>{{o|safe}}</p>
     {% endfor %}


### PR DESCRIPTION
Texto rico sendo renderizado sem filter safe incluído html no PDF. 

Erro apresentado por usuário no discord, canal #sapl_dev em 21/09/2023
![image](https://github.com/interlegis/sapl/assets/9630623/3b47f6cc-dd61-4f0d-8551-8086c50ec265)
