### PR TITLE
Conserta relatoria de matérias

### DIFF
--- a/sapl/crispy_layout_mixin.py
+++ b/sapl/crispy_layout_mixin.py
@@ -284,7 +284,7 @@ class CrispyLayoutFormMixin:
             'text': field_display,
         }
 
-    def fk_urlize_for_detail(self, obj, fieldname):
+    def fk_urlify_for_detail(self, obj, fieldname):
 
         field = obj._meta.get_field(fieldname)
         value = getattr(obj, fieldname)
@@ -297,6 +297,14 @@ class CrispyLayoutFormMixin:
             value)
 
         return field.verbose_name, display
+
+    def fk_urlify_for_list(self, obj, field):
+        value = getattr(obj, field)
+        return reverse(
+                        '%s:%s_detail' % (
+                            value._meta.app_config.name,
+                            value._meta.model_name),
+                        kwargs={'pk': value.id}),
 
     def m2m_urlize_for_detail(self, obj, fieldname):
 

--- a/sapl/materia/views.py
+++ b/sapl/materia/views.py
@@ -1337,6 +1337,9 @@ class RelatoriaCrud(MasterDetailCrud):
 
             return {'comissao': localizacao}
 
+    class ListView(MasterDetailCrud.ListView):
+        layout_key = 'RelatoriaList'
+
     class UpdateView(MasterDetailCrud.UpdateView):
         form_class = RelatoriaForm
         layout_key = None

--- a/sapl/templates/materia/layouts.yaml
+++ b/sapl/templates/materia/layouts.yaml
@@ -59,8 +59,8 @@ Anexada:
 
 AnexadaDetail:
   {% trans 'Matéria Anexada' %}:
-  - materia_principal|fk_urlize_for_detail
-  - materia_anexada|fk_urlize_for_detail
+  - materia_principal|fk_urlify_for_detail
+  - materia_anexada|fk_urlify_for_detail
   - data_anexacao  data_desanexacao
 
 Autoria:
@@ -86,10 +86,17 @@ Orgao:
 
 Relatoria:
   {% trans 'Relatoria' %}:
-  - comissao|fk_urlize_for_detail
-  - materia|fk_urlize_for_detail
+  - comissao
+  - materia
   - data_designacao_relator data_destituicao_relator
   - parlamentar tipo_fim_relatoria
+
+RelatoriaList:
+  {% trans 'Relatoria' %}:
+  - comissao
+  - materia|fk_urlify_for_list
+  - data_designacao_relator data_destituicao_relator
+  - parlamentar|fk_urlify_for_list tipo_fim_relatoria
 
 TipoProposicao:
   {% trans 'Tipo Proposição' %}:

--- a/sapl/templates/norma/layouts.yaml
+++ b/sapl/templates/norma/layouts.yaml
@@ -51,7 +51,7 @@ LegislacaoCitada:
 
 LegislacaoCitadaDetail:
   {% trans 'Legislação Citada' %}:
-  - norma|fk_urlize_for_detail
+  - norma|fk_urlify_for_detail
   - disposicoes  parte  livro  titulo
   - capitulo  secao  subsecao  artigo
   - paragrafo  inciso  alinea  item

--- a/sapl/templates/protocoloadm/layouts.yaml
+++ b/sapl/templates/protocoloadm/layouts.yaml
@@ -43,8 +43,8 @@ Anexado:
 
 AnexadoDetail:
   {% trans 'Documento Anexado' %}:
-  - documento_principal|fk_urlize_for_detail
-  - documento_anexado|fk_urlize_for_detail
+  - documento_principal|fk_urlify_for_detail
+  - documento_anexado|fk_urlify_for_detail
   - data_anexacao  data_desanexacao
 
 Protocolo:
@@ -70,5 +70,5 @@ VinculoDocAdminMateria:
 
 VinculoDocAdminMateriaDetail:
   {% trans 'Matéria Vinculada' %}:
-  - materia|fk_urlize_for_detail data_anexacao:3 data_desanexacao:3
+  - materia|fk_urlify_for_detail data_anexacao:3 data_desanexacao:3
   - documento

--- a/sapl/templates/sessao/blocos_ata/ocorrencias_da_sessao.html
+++ b/sapl/templates/sessao/blocos_ata/ocorrencias_da_sessao.html
@@ -3,7 +3,6 @@
         <p style="text-align: justify;margin-top: 0">
             <strong>Ocorrências da Sessão: </strong>
             {{ object.ocorrenciasessao.conteudo|striptags|safe }}
-
         </p>
     </fieldset>
 {% endif %}

--- a/sapl/templates/sessao/layouts.yaml
+++ b/sapl/templates/sessao/layouts.yaml
@@ -133,5 +133,5 @@ Correspondencia:
 CorrespondenciaDetail:
   {% trans 'Correspondencia' %}:
   - numero_ordem:2 tipo:3 sessao_plenaria
-  - documento|fk_urlize_for_detail
+  - documento|fk_urlify_for_detail
   - observacao


### PR DESCRIPTION
Os links da listagem de relatória não estavam habilitados.

## Descrição
Após a adição das função fk_urlize_for_detail nos campos comissão e matéria os links não foram habilitados pois essa função não estava adaptada para listagem (ListView), mas para detalhes (DetailView). Também foi refatorado o nome das funções de que retornam a URL.

## _Issue_ Relacionada
#3682 

## Motivação e Contexto
Consertar o bug conforme relatado no OSTickets #483334 e #925555.

## Como Isso Foi Testado?
Manualmente.

## Capturas de Tela (se apropriado):
![image](https://github.com/interlegis/sapl/assets/9326037/510d855b-bd36-4bb0-bfbb-799a1223edec)


![image](https://github.com/interlegis/sapl/assets/9326037/c35ca0df-9fba-4ff1-86bd-b19a636ee9f5)

## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [X] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [X] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [X] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [ ] Todos os testes novos e existentes passaram.