### PR TITLE
fix: corrige bug na common tag format_user

### DIFF
--- a/sapl/base/templatetags/common_tags.py
+++ b/sapl/base/templatetags/common_tags.py
@@ -84,6 +84,9 @@ def desc_operation(value):
 
 @register.filter
 def format_user(user):
+    if not user:
+        return ""
+
     if user.first_name:
         return user.first_name + " " + user.last_name + " (" + user.username + ")"
     else:


### PR DESCRIPTION
<!--- Forneça um resumo geral das suas alterações no título acima -->

## Descrição
corrige erro quando a common tag format_user(user) recebe um objeto nulo


## Motivação e Contexto
Desde a criacao do usuario responsavel pela acao, proposicoes antigas contem usuario.envio vazio, pois era considerado o autor da proposicao, nesses casos havia uma excecao na tag

## Como Isso Foi Testado?
localmente


## Tipos de Mudanças
<!--- Quais os tipos de alterações introduzidos pelo seu código? Coloque um `x` em todas as caixas que se aplicam: -->
- [x ] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:
<!--- Passe por todos os pontos a seguir e coloque um `x` em todas as caixas que se aplicam. -->
<!--- Se você não tem certeza sobre nenhum destes, não hesite em perguntar. Nós estamos aqui para ajudar! -->
- [ x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [ x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x ] Todos os testes novos e existentes passaram.