### PR TITLE
Corrige polling excessivo e bloqueia não-votantes em /voto-individual/

### DIFF
--- a/sapl/painel/views.py
+++ b/sapl/painel/views.py
@@ -3,8 +3,9 @@ import json
 import logging
 
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required, user_passes_test
-from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.decorators import (login_required, permission_required,
+                                            user_passes_test)
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.urls import reverse
 from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
@@ -200,39 +201,22 @@ def can_vote(context, context_vars, request):
 
 
 @login_required
+@permission_required('parlamentares.can_vote', raise_exception=True)
 def votante_view(request):
     logger = logging.getLogger(__name__)
-    username = request.user.username if request.user.is_authenticated else 'AnonymousUser'
- 
-    # Pega o votante relacionado ao usuário
+    username = request.user.username
+
+    if not Votante.objects.filter(user=request.user).exists():
+        logger.warning(
+            f'user={username} sem cadastro de Votante tentou acessar /voto-individual/.'
+        )
+        raise PermissionDenied
+
     template_name = 'painel/voto_individual.html'
-    context = {}
-    context_vars = {}
-
-    try:
-        logger.debug(f'user={username}. Tentando obter objeto Votante com user={request.user}.')
-        if not request.user.is_anonymous and request.user.is_authenticated:
-            votante = Votante.objects.get(user=request.user)
-        else:
-            raise ObjectDoesNotExist
-    except ObjectDoesNotExist:
-        logger.error(f"user={username}. Usuário (user={request.user}) não cadastrado como votante na tela de parlamentares. " 
-                     "Contate a administração de sua Casa Legislativa!")
-        msg = _("Usuário não cadastrado como votante na tela de parlamentares. Contate a administração de sua Casa Legislativa!")
-        context.update({'error_message': msg})
-
-        return render(request, template_name, context)
-    context_vars = {'votante': votante}
     context = {'head_title': str(_('Votação Individual'))}
+    context_vars = {'votante': Votante.objects.get(user=request.user)}
 
-    # Verifica se usuário possui permissão para votar
-    if 'parlamentares.can_vote' in request.user.get_all_permissions():
-        context, context_vars = can_vote(context, context_vars, request)
-        logger.debug("user=" + username + ". Verificando se usuário {} possui permissão para votar.".format(request.user))
-    else:
-        logger.error("user=" + username + ". Usuário {} sem permissão para votar.".format(request.user))
-        context.update({'permissao': False,
-                        'error_message': 'Usuário sem permissão para votar.'})
+    context, context_vars = can_vote(context, context_vars, request)
 
     # Salva o voto
     if request.method == 'POST':

--- a/sapl/painel/views.py
+++ b/sapl/painel/views.py
@@ -3,7 +3,7 @@ import json
 import logging
 
 from django.contrib import messages
-from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 from django.db.models import Q
@@ -199,6 +199,7 @@ def can_vote(context, context_vars, request):
     return context, context_vars
 
 
+@login_required
 def votante_view(request):
     logger = logging.getLogger(__name__)
     username = request.user.username if request.user.is_authenticated else 'AnonymousUser'

--- a/sapl/templates/painel/voto_individual.html
+++ b/sapl/templates/painel/voto_individual.html
@@ -127,10 +127,11 @@
     </body>
 </html>
 
+{% if not error_message %}
 {% render_chunk_vendors 'js' %}
-{% render_bundle  'global' 'js' %}  
-{% render_bundle  'painel' 'js' %}      
-    
+{% render_bundle  'global' 'js' %}
+{% render_bundle  'painel' 'js' %}
+
 <script type="text/javascript">
 
   $(window).on('beforeunload', function () {
@@ -162,7 +163,7 @@
 
   function checkTime(i) {
     if (i<10)
-      i = "0" + i; // add zero in front of numbers < 10  
+      i = "0" + i; // add zero in front of numbers < 10
     return i;
   }
 
@@ -174,7 +175,7 @@
     m = checkTime(m);
     s = checkTime(s);
     $("#relogio").text(h+":"+m+":"+s)
-    var t = setInterval(() => startTime(), 500);
+    var t = setTimeout(() => startTime(), 500);
   }
 
   $(document).ready(function(){
@@ -183,10 +184,11 @@
     $("#date").text(n);
 
     startTime();
-    
+
     setTimeout(function() {
       document.location.reload(true);
     }, 30000)
   });
 
 </script>
+{% endif %}


### PR DESCRIPTION
## Descrição

Dois ajustes na rota `/voto-individual/` para reduzir disparos do rate-limiter (observados nos logs do Elasticsearch) e fechar o endpoint para identidades que não podem votar.

**Polling / auto-reload** (`sapl/templates/painel/voto_individual.html`)

- Corrige bug do relógio onde `setInterval(() => startTime(), 500)` era chamado dentro de `startTime`, fazendo o número de timers dobrar a cada 500 ms (substituído por `setTimeout` recursivo simples).
- O `<script>` com o `setTimeout` de recarregar a página a cada 30 s e o relógio agora ficam dentro de `{% if not error_message %}`, então a variante de erro do template não dispara reloads.

**Bloqueio de identidade** (`sapl/painel/views.py`)

- `votante_view` agora exige `@login_required` + `@permission_required('parlamentares.can_vote', raise_exception=True)`, mais uma checagem inline de `Votante.objects.filter(user=...).exists()` para pegar superusers (que passam pelo bypass automático de permissões do Django mas não têm cadastro de Votante) e custom groups que conceda `can_vote` sem o cadastro.
- Falhas de identidade agora retornam HTTP 403; antes retornavam 200 com um template de erro que ainda carregava o JS de polling.
- Mantém HTTP 200 com mensagem amigável para falhas de estado que um votante legítimo pode encontrar (nenhuma matéria aberta, parlamentar não presente na sessão).

## _Issue_ Relacionada

N/A — observação direta de logs do rate-limiter.

## Motivação e Contexto

Logs mostravam volume desproporcional de 429s saindo de um único IP NAT (vereadores de uma casa atrás da mesma saída pública), com `/voto-individual/` na liderança ao lado de paths como `/sessao/pauta-sessao/45/`, `/sessao/45/ordemdia`, `/materia/1512`, `/`.

Causa raiz no `/voto-individual/`:

1. O template auto-recarregava a tela a cada 30 s (`setTimeout(...reload..., 30000)`).
2. A view não tinha `@login_required`: usuários anônimos recebiam o template de erro com o auto-reload junto, mantendo o loop de fora — qualquer aba esquecida aberta gerava reloads indefinidos.
3. Bug do `setInterval` recursivo do relógio degradava a aba (timers dobravam a cada 500 ms), levando usuários a apertar F5.

Com o auth-gate forte, o JS isolado da variante de erro e o relógio corrigido, o endpoint passa a gerar tráfego apenas a partir de votantes legítimos com sessão ativa.

## Como Isso Foi Testado?

Smoke tests E2E contra dump de produção restaurado no ambiente dev:

- Anônimo → 302 para `/login/?next=/voto-individual/`, body 0 bytes (sem vazamento de JS de polling).
- Logado sem Votante (superuser `admin`) → 403, body 9 bytes, sem template.
- Logado com Votante + `can_vote` (parlamentar `carlos`) → 200 com botões Sim/Não/Abstenção, JS de reload presente, bug do relógio ausente.
- `python3 manage.py check` sem issues; sem tracebacks no log do dev server.
- Render direto via `render_to_string` confirmando: branch de sucesso carrega o `<script>`, branch de erro não.

## Tipos de Mudanças

- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:

- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [ ] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram.