### PR TITLE
Corrige ordem dos expedientes no PDF do Resumo da Sessão

### DIFF
--- a/sapl/relatorios/tests.py
+++ b/sapl/relatorios/tests.py
@@ -1,3 +1,52 @@
-# from django.test import TestCase
+import pytest
+from model_bakery import baker
 
-# Create your tests here.
+from sapl.base.models import CasaLegislativa
+from sapl.relatorios.views import get_sessao_plenaria
+from sapl.sessao.models import ExpedienteSessao, SessaoPlenaria, TipoExpediente
+from sapl.sessao.views import get_expedientes
+
+
+def cria_sessao_com_expedientes():
+    """Cria uma sessão cujos expedientes têm `ordenacao` inversa à ordem
+    alfabética dos nomes -- o caso que expõe o OSTicket #125461."""
+    sessao = baker.make(SessaoPlenaria)
+    tipo_leitura = baker.make(
+        TipoExpediente, nome='Leitura e Aprovação da Ata', ordenacao=1)
+    tipo_grande = baker.make(
+        TipoExpediente, nome='Grande Expediente', ordenacao=2)
+
+    for tipo in (tipo_grande, tipo_leitura):
+        baker.make(ExpedienteSessao, sessao_plenaria=sessao, tipo=tipo,
+                   conteudo='<p>Conteúdo de {}.</p>'.format(tipo.nome))
+
+    return sessao
+
+
+@pytest.mark.django_db(transaction=False)
+def test_relatorio_sessao_respeita_ordenacao_do_tipo_expediente():
+    """O PDF da Sessão Plenária deve seguir o campo `ordenacao` de
+    TipoExpediente, e não a ordem alfabética do nome."""
+    sessao = cria_sessao_com_expedientes()
+    casa = baker.make(CasaLegislativa)
+    user = baker.make('auth.User')
+
+    lst_expedientes = get_sessao_plenaria(sessao, casa, user)[6]
+    nomes = [e['nom_expediente'] for e in lst_expedientes]
+
+    assert nomes == ['Leitura e Aprovação da Ata', 'Grande Expediente']
+
+
+@pytest.mark.django_db(transaction=False)
+def test_relatorio_sessao_tem_mesma_ordem_de_expedientes_do_resumo():
+    """O PDF e o Resumo exibido em tela não podem divergir: foi essa
+    divergência que originou o OSTicket #125461."""
+    sessao = cria_sessao_com_expedientes()
+    casa = baker.make(CasaLegislativa)
+    user = baker.make('auth.User')
+
+    do_pdf = [e['nom_expediente']
+              for e in get_sessao_plenaria(sessao, casa, user)[6]]
+    da_tela = [e['tipo'].nome for e in get_expedientes(sessao)['expedientes']]
+
+    assert do_pdf == da_tela

--- a/sapl/relatorios/views.py
+++ b/sapl/relatorios/views.py
@@ -609,8 +609,10 @@ def get_sessao_plenaria(sessao, casa, user):
 
     # Exibe os Expedientes
     lst_expedientes = []
+    # A ordenação deve ser a mesma de sapl.sessao.views.get_expedientes, para
+    # que o PDF confira com o Resumo exibido em tela. OSTicket #125461
     expedientes = ExpedienteSessao.objects.filter(
-        sessao_plenaria=sessao).order_by('tipo__nome')
+        sessao_plenaria=sessao).order_by('tipo__ordenacao', 'tipo__nome')
     for e in expedientes:
         conteudo = e.conteudo
         if not is_empty(conteudo):


### PR DESCRIPTION
## Descrição

O PDF do Resumo da Sessão (`relatorio_sessao_plenaria_pdf`) ordenava os expedientes **alfabeticamente pelo nome do tipo**, ignorando o campo `ordenacao` de `TipoExpediente`.

A correção alinha `get_sessao_plenaria` (`sapl/relatorios/views.py`) à ordenação que `sapl.sessao.views.get_expedientes` já usava:

```diff
-        sessao_plenaria=sessao).order_by('tipo__nome')
+        sessao_plenaria=sessao).order_by('tipo__ordenacao', 'tipo__nome')
```

Como a mudança está no _helper_ compartilhado, ela corrige os dois _callers_ vivos de `get_sessao_plenaria`.

## _Issue_ Relacionada

Não há _issue_ no GitHub para este caso — a correção atende ao **OSTicket #125461**.

## Motivação e Contexto

Regressão silenciosa entre dois caminhos que deveriam concordar:

| Caminho | _Helper_ | `order_by` |
|---|---|---|
| PDF do Resumo (botão em `resumo.html`) | `get_sessao_plenaria` | `tipo__nome` ❌ |
| Tela do Resumo / Extrato | `get_expedientes` | `tipo__ordenacao, tipo__nome` ✅ |

O `order_by('tipo__nome')` foi introduzido em 25be37eb *justamente* para "ficar em conformidade com o resumo" — correto à época, pois `TipoExpediente` ainda não possuía campo de ordenação. Quando 2eb0b796 (#2920) criou o campo `ordenacao`, apenas `sapl/sessao/views.py` foi atualizado e o relatório em PDF ficou para trás.

O efeito é que a ordem cadastrada pela Casa é ignorada e o PDF sai em ordem alfabética. Com os tipos usuais, "Grande Expediente" passa à frente de "Leitura e Aprovação da Ata", e "Encerramento da Sessão" pode ser impresso logo após "Abertura da Sessão" — antes mesmo da leitura da ata. Como o Resumo costuma ser usado como Pauta enviada aos vereadores, o documento circula com a sessão fora de ordem.

Vale notar que `ExpedienteSessao.Meta.ordering` é `('id',)`, então qualquer consulta sem `order_by` explícito cai em ordem de inserção. Este PR corrige apenas o caminho do relatório reportado no chamado; os demais pontos ficam para uma discussão à parte.

## Como Isso Foi Testado?

Ambiente: _stack_ Docker do projeto (Postgres 10.5), com base de teste contendo tipos de expediente cuja `ordenacao` é inversa à ordem alfabética dos nomes.

1. **Reprodução no endpoint real** — `GET /relatorios/<pk>/sessao-plenaria-pdf` retornando `200 application/pdf`, com o PDF gerado pelo WeasyPrint e o texto extraído do arquivo para conferir a ordem dos expedientes. Confirmado em ordem errada antes da correção e correta depois.
2. **Validação no navegador** — PDF aberto e conferido em tela, antes e depois.
3. **Varredura** — em todas as sessões com expediente da base de teste, o PDF passou a coincidir com a tela do Resumo (0 divergências).
4. **Testes de regressão** (`sapl/relatorios/tests.py`) — verificados **falhando sem a correção** e passando com ela.
5. **flake8** — sem novos avisos nos arquivos alterados.

> ⚠️ Ressalva: `sapl/sessao/` possui **8 testes que já falham na 3.1.x sem estas alterações** (`AttributeError: 'TestResumoView' object has no attribute 'sessao_plenaria'`). São pré-existentes e alheios a este PR — confirmado executando a suíte no HEAD limpo.

> ℹ️ Nota: `pytest-django` não está fixado em `requirements/test-requirements.txt`, embora `pytest.ini` dependa dele. Instalá-lo sem restrição traz o Django 5 e quebra o _lock_ do Django 2.2 (`cannot import name 'utc'`). Usei `pytest-django==4.5.2` para rodar a suíte.

## Capturas de Tela (se apropriado):

Não aplicável — a mudança não altera _layout_, apenas a ordem dos blocos já existentes.

## Tipos de Mudanças

- [x] _Bug fix_ (alteração que corrige uma _issue_ e não altera funcionalidades já existentes)
- [ ] Nova _feature_ (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes)
- [ ] Alteração disruptiva (_Breaking change_) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes)

## Checklist:

- [x] Eu li o documento de Contribuição (**CONTRIBUTING**).
- [x] Meu código segue o estilo de código deste projeto.
- [ ] Minha alteração requer uma alteração na documentação.
- [ ] Eu atualizei a documentação de acordo.
- [x] Eu adicionei testes para cobrir minhas mudanças.
- [x] Todos os testes novos e existentes passaram (ver ressalva acima).
